### PR TITLE
Adds expect_column_distinct_count_** tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,31 @@ tests:
 
 ### Aggregate functions
 
+
+#### [expect_column_distinct_count_to_equal](macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql)
+
+Expect the number of distinct column values to be equal to a given value.
+
+*Applies to:* Column
+
+```yaml
+tests:
+  - dbt_expectations.expect_column_distinct_count_to_equal:
+      value: 10
+```
+
+#### [expect_column_distinct_count_to_be_greater_than](macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_greater_than.sql)
+
+Expect the number of distinct column values to be greater than a given value.
+
+*Applies to:* Column
+
+```yaml
+tests:
+  - dbt_expectations.expect_column_distinct_count_to_be_greater_than:
+      value: 10
+```
+
 #### [expect_column_distinct_values_to_be_in_set](macros/schema_tests/aggregate_functions/expect_column_distinct_values_to_be_in_set.sql)
 
 Expect the set of distinct column values to be contained by a given set.

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -22,7 +22,6 @@ models:
               like_pattern_list: ["%@%", "%&%"]
 
 
-
   - name: timeseries_data
     tests:
         - dbt_expectations.expect_table_columns_to_match_ordered_list:
@@ -39,6 +38,7 @@ models:
               column_type_list: [date, datetime]
           - dbt_expectations.expect_column_values_to_be_increasing:
               sort_column: date_day
+
       - name: row_value
         tests:
           - dbt_expectations.expect_column_values_to_be_within_n_stdevs:
@@ -47,6 +47,29 @@ models:
               group_by: date_day
               sigma_threshold: 6
               take_logs: true
+
+
+  - name: timeseries_data_extended
+    tests:
+        - dbt_expectations.expect_table_columns_to_match_ordered_list:
+            column_list: ["date_day", "row_value", "row_value_log"]
+    columns:
+      - name: date_day
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: date
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list: [date, datetime]
+
+      - name: row_value
+        tests:
+          - dbt_expectations.expect_column_distinct_count_to_equal:
+              row_condition: date_day = {{ dbt_date.yesterday() }}
+              value: 10
+
       - name: row_value_log
         tests:
           - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -69,6 +69,10 @@ models:
           - dbt_expectations.expect_column_distinct_count_to_equal:
               row_condition: date_day = {{ dbt_date.yesterday() }}
               value: 10
+          - dbt_expectations.expect_column_distinct_count_to_be_greater_than:
+              row_condition: date_day = {{ dbt_date.yesterday() }}
+              value: 1
+
 
       - name: row_value_log
         tests:

--- a/integration_tests/models/schema_tests/timeseries_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_extended.sql
@@ -7,9 +7,11 @@ add_row_values as (
 
     select
         d.date_day,
-        cast(floor(100 * abs({{ dbt_expectations.rand() }})) as {{ dbt_utils.type_int() }}) as row_value
+        cast(floor(100 * rnd) as {{ dbt_utils.type_int() }}) as row_value
     from
         dates d
+        cross join
+        unnest(generate_array(1, 10)) as rnd
 
 ),
 add_logs as (

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_greater_than.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_greater_than.sql
@@ -1,0 +1,14 @@
+{% macro test_expect_column_distinct_count_to_be_greater_than(model,
+                                                                column_name,
+                                                                value,
+                                                                quote_values=False,
+                                                                row_condition=None
+                                                                ) %}
+{% set expression %}
+count(distinct {{ column_name }}) > {{ value }}
+{% endset %}
+{{ dbt_expectations.expression_is_true(model,
+                                        expression=expression,
+                                        row_condition=row_condition)
+                                        }}
+{%- endmacro -%}

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql
@@ -1,0 +1,16 @@
+{% macro test_expect_column_distinct_count_to_equal(model,
+                                                    column_name,
+                                                    value,
+                                                    quote_values=False,
+                                                    group_by_columns=None,
+                                                    row_condition=None
+                                                    ) %}
+{% set expression %}
+count(distinct {{ column_name }}) = {{ value }}
+{% endset %}
+{{ dbt_expectations.expression_is_true(model,
+                                        expression=expression,
+                                        group_by_columns=group_by_columns,
+                                        row_condition=row_condition)
+                                        }}
+{%- endmacro -%}

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql
@@ -2,7 +2,6 @@
                                                     column_name,
                                                     value,
                                                     quote_values=False,
-                                                    group_by_columns=None,
                                                     row_condition=None
                                                     ) %}
 {% set expression %}
@@ -10,7 +9,6 @@ count(distinct {{ column_name }}) = {{ value }}
 {% endset %}
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by_columns,
                                         row_condition=row_condition)
                                         }}
 {%- endmacro -%}


### PR DESCRIPTION
Adds `expect_column_distinct_count_to_equal` and `expect_column_distinct_count_to_be_greater_than` to allow testing for a defined number of unique values in a column. 
For example, this could be used to check for the unique number of `batch_id` values in a given day (filtered via `row_condition`).

```
- name: my_fact_table
  columns:
    - name: batch_id
      tests:
        - dbt_expectations.expect_column_distinct_count_to_equal:
            row_condition: date_day = {{ dbt_date.yesterday() }}
            value: 24
```


```
- name: my_fact_table
  columns:
    - name: batch_id
      tests:
        - dbt_expectations.expect_column_distinct_count_to_be_greater_than:
            row_condition: date_day = {{ dbt_date.yesterday() }}
            value: 12
```