### PR TITLE
Refactor single & multi-column uniqueness tests

### DIFF
--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_unique.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_unique.sql
@@ -1,24 +1,3 @@
 {% macro test_expect_column_values_to_be_unique(model, column_name, row_condition=None) %}
-
-with column_values as (
-
-    select
-        {{ column_name }} as column_name
-    from {{ model }}
-    where 1=1
-    {% if row_condition %}
-        and {{ row_condition }}
-    {% endif %}
-
-),
-validation_errors as (
-
-    select
-        column_name
-    from column_values
-    group by 1
-    having count(*) > 1
-
-)
-select count(*) from validation_errors
+{{ dbt_expectations.test_expect_compound_columns_to_be_unique(model, [column_name], row_condition=row_condition) }}
 {% endmacro %}


### PR DESCRIPTION
Makes SQL output for multi-column uniqueness checks a little more readable by forgoing the surrogate key construction.