### PR TITLE
Refactor expect_column_values_to_be_within_n_moving_stdevs

### DIFF
--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -44,15 +44,15 @@ models:
           - dbt_expectations.expect_column_values_to_be_within_n_stdevs:
               sigma_threshold: 6
           - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
-              group_by: date_day
+              date_column_name: date_day
               sigma_threshold: 6
               take_logs: true
-
 
   - name: timeseries_data_extended
     tests:
         - dbt_expectations.expect_table_columns_to_match_ordered_list:
             column_list: ["date_day", "row_value", "row_value_log"]
+
     columns:
       - name: date_day
         tests:
@@ -77,9 +77,33 @@ models:
       - name: row_value_log
         tests:
           - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
-              group_by: date_day
+              date_column_name: cast(date_day as datetime)
               sigma_threshold: 6
               take_logs: false
+
+  - name: timeseries_hourly_data_extended
+    columns:
+      - name: date_hour
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: hour
+              interval: 12
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: datetime
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list: [date, datetime]
+
+
+      - name: row_value_log
+        tests:
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: cast(date_hour as datetime)
+              period: hour
+              trend_periods: 48
+              test_periods: 12
+              sigma_threshold: 6
+              take_logs: true
+
 
   - name: data_test
     tests:

--- a/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
@@ -1,0 +1,31 @@
+with dates as (
+
+    {{ dbt_utils.date_spine('hour',
+        start_date=dbt_date.n_days_ago(10),
+        end_date=dbt_date.today()
+        ) }}
+
+),
+add_row_values as (
+
+    select
+        d.date_hour,
+        cast(floor(100 * rnd) as {{ dbt_utils.type_int() }}) as row_value
+    from
+        dates d
+        cross join
+        unnest(generate_array(1, 10)) as rnd
+
+),
+add_logs as (
+
+    select
+        *,
+        {{ dbt_expectations.log_natural('nullif(row_value, 0)') }} as row_value_log
+    from
+        add_row_values
+)
+select
+    *
+from
+    add_logs


### PR DESCRIPTION
This refactor would allow users to specify a period other than 'day' for their timeseries tests.

This is a **breaking change** as the macro renames to following parameters:
- `group_by` --> `date_column_name`
- `lookback_days` --> `lookback_periods`
- `trend_days` --> `trend_periods`
- `test_days` --> `test_periods`
