### PR TITLE
Refactor column type checks to use dtype

### DIFF
--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -8,7 +8,7 @@
     {%- set matching_column_types = [] -%}
 
     {%- for column in columns_in_relation -%}
-        {%- if ((column.name | upper ) == column_name) and ((column.data_type | upper ) in column_type_list) -%}
+        {%- if ((column.name | upper ) == column_name) and ((column.dtype | upper ) in column_type_list) -%}
             {%- do matching_column_types.append(column.name) -%}
         {%- endif -%}
     {%- endfor -%}

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_of_type.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_of_type.sql
@@ -1,18 +1,4 @@
 {%- macro test_expect_column_values_to_be_of_type(model, column_name, column_type) -%}
-{%- if execute -%}
-
-    {%- set column_name = column_name | upper -%}
-    {%- set columns_in_relation = adapter.get_columns_in_relation(model) -%}
-    {%- set column_type = column_type| upper -%}
-
-    {%- set matching_column_types = [] -%}
-
-    {%- for column in columns_in_relation -%}
-        {%- if ((column.name | upper ) == column_name) and ((column.data_type | upper ) == column_type) -%}
-            {%- do matching_column_types.append(column.name) -%}
-        {%- endif -%}
-    {%- endfor -%}
-    select 1 - {{ matching_column_types | length }}
-
-{%- endif -%}
+{{ dbt_expectations.test_expect_column_values_to_be_in_type_list(model, column_name, [column_type]) }}
 {%- endmacro -%}
+


### PR DESCRIPTION
Refactors `expect_column_values_to_be_of_type` and `expect_column_values_to_be_in_type_list` to use `Column.dtype` instead of `data_type` to make type comparisons easier.

Fixes #22  