### PR TITLE
Modifications for tsql support

### DIFF
--- a/macros/schema_tests/_generalized/equal_expression.sql
+++ b/macros/schema_tests/_generalized/equal_expression.sql
@@ -1,4 +1,8 @@
-{%- macro get_select(model, expression, row_condition, group_by) %}
+{% macro get_select(model, expression, row_condition, group_by) -%}
+    {{ adapter.dispatch('get_select', packages = dbt_expectations._get_namespaces()) (model, expression, row_condition, group_by) }}
+{%- endmacro %}
+
+{%- macro default__get_select(model, expression, row_condition, group_by) %}
     select
         {% for g in group_by -%}
             {{ g }} as col_{{ loop.index }},
@@ -16,7 +20,8 @@
         {% endfor %}
 {% endmacro -%}
 
-{%- macro test_equal_expression(model, expression,
+
+{% macro test_equal_expression(model, expression,
                                 compare_model=None,
                                 compare_expression=None,
                                 group_by=["'col'"],
@@ -25,6 +30,26 @@
                                 compare_row_condition=None,
                                 tolerance=0.0,
                                 tolerance_percent=None) -%}
+    {{ adapter.dispatch('test_equal_expression', packages = dbt_expectations._get_namespaces()) (model, expression,
+                                compare_model,
+                                compare_expression,
+                                group_by,
+                                compare_group_by,
+                                row_condition,
+                                compare_row_condition,
+                                tolerance,
+                                tolerance_percent) }}
+{%- endmacro %}
+
+{%- macro default__test_equal_expression(model, expression,
+                                compare_model,
+                                compare_expression,
+                                group_by,
+                                compare_group_by,
+                                row_condition,
+                                compare_row_condition,
+                                tolerance,
+                                tolerance_percent) -%}
 
     {%- set compare_model = model if not compare_model else compare_model -%}
     {%- set compare_expression = expression if not compare_expression else compare_expression -%}

--- a/macros/schema_tests/_generalized/expression_is_true.sql
+++ b/macros/schema_tests/_generalized/expression_is_true.sql
@@ -15,6 +15,10 @@
                                  group_by_columns=None,
                                  row_condition=None
                                  ) %}
+    {{ adapter.dispatch('expression_is_true', packages = dbt_expectations._get_namespaces()) (model, expression, test_condition, group_by_columns, row_condition) }}
+{%- endmacro %}
+
+{% macro default__expression_is_true(model, expression, test_condition, group_by_columns, row_condition) %}
 
 
 with grouped_expression as (

--- a/macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
@@ -4,6 +4,16 @@
                                                             quote_values=False,
                                                             data_type="decimal",
                                                             row_condition=None
+                                                            ) -%}
+    {{ adapter.dispatch('test_expect_column_most_common_value_to_be_in_set', packages = dbt_expectations._get_namespaces()) (model, column_name, value_set, top_n, quote_values, data_type, row_condition) }}
+{%- endmacro %}
+
+{% macro default__test_expect_column_most_common_value_to_be_in_set(model, column_name,
+                                                            value_set,
+                                                            top_n,
+                                                            quote_values,
+                                                            data_type,
+                                                            row_condition
                                                             ) %}
 
 with value_counts as (

--- a/macros/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql
@@ -2,6 +2,18 @@
                                                     min_value,
                                                     max_value,
                                                     row_condition=None
+                                                    ) -%}
+    {{ adapter.dispatch('test_expect_column_stdev_to_be_between', packages = dbt_expectations._get_namespaces()) (model, column_name,
+                                                    min_value,
+                                                    max_value,
+                                                    row_condition
+                                                    ) }}
+{%- endmacro %}
+
+{% macro default__test_expect_column_stdev_to_be_between(model, column_name,
+                                                    min_value,
+                                                    max_value,
+                                                    row_condition
                                                     ) %}
 
 {% set expression %}

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -21,6 +21,34 @@ coalesce({{ metric_column }}, 0)
                                   sigma_threshold_lower=None,
                                   take_diffs=true,
                                   take_logs=true
+                                ) -%}
+    {{ adapter.dispatch('test_expect_column_values_to_be_within_n_moving_stdevs', packages = dbt_expectations._get_namespaces()) (model,
+                                  column_name,
+                                  date_column_name,
+                                  period,
+                                  lookback_periods,
+                                  trend_periods,
+                                  test_periods,
+                                  sigma_threshold,
+                                  sigma_threshold_upper,
+                                  sigma_threshold_lower,
+                                  take_diffs,
+                                  take_logs
+                                ) }}
+{%- endmacro %}
+
+{% macro default__test_expect_column_values_to_be_within_n_moving_stdevs(model,
+                                  column_name,
+                                  date_column_name,
+                                  period,
+                                  lookback_periods,
+                                  trend_periods,
+                                  test_periods,
+                                  sigma_threshold,
+                                  sigma_threshold_upper,
+                                  sigma_threshold_lower,
+                                  take_diffs,
+                                  take_logs
                                 ) %}
 
 {%- set sigma_threshold_upper = sigma_threshold_upper if sigma_threshold_upper else sigma_threshold -%}

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
@@ -2,6 +2,14 @@
                                   column_name,
                                   group_by=None,
                                   sigma_threshold=3
+                                ) -%}
+    {{ adapter.dispatch('test_expect_column_values_to_be_within_n_stdevs', packages = dbt_expectations._get_namespaces()) (model, column_name, group_by, sigma_threshold) }}
+{%- endmacro %}
+
+{% macro default__test_expect_column_values_to_be_within_n_stdevs(model,
+                                  column_name,
+                                  group_by,
+                                  sigma_threshold
                                 ) %}
 with metric_values as (
 

--- a/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
+++ b/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
@@ -3,6 +3,15 @@
                                                     quote_columns=False,
                                                     ignore_row_if="all_values_are_missing",
                                                     row_condition=None
+                                                    )  -%}
+    {{ adapter.dispatch('test_expect_select_column_values_to_be_unique_within_record', packages = dbt_expectations._get_namespaces()) (model, column_list, quote_columns, ignore_row_if, row_condition) }}
+{%- endmacro %}
+
+{% macro default__test_expect_select_column_values_to_be_unique_within_record(model,
+                                                    column_list,
+                                                    quote_columns,
+                                                    ignore_row_if,
+                                                    row_condition
                                                     ) %}
 
 {% if not quote_columns %}

--- a/macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql
+++ b/macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql
@@ -3,7 +3,7 @@
 {%- set number_actual_columns = (adapter.get_columns_in_relation(model) | length) -%}
 select
     case
-        when {{ number_actual_columns >= min_value and number_actual_columns <= max_value }}
+        when {{ number_actual_columns }} >= {{ min_value }} and {{ number_actual_columns }} <= {{ max_value }}
         then 0 else 1
     end
 {%- endif -%}


### PR DESCRIPTION
Hi!

I have been working on a package to port this package to T-SQL. 
Some of the macros require the `adapter.dispatch` call for me to able to override the default version.

If those changes are accepted I should be able to release `dbt-expectations-tsql` shortly.

Cheers,