### PR TITLE
Add expect_table_column_count_to_equal_other_table_times_factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ models: # or seeds:
         compare_model: ref("other_model")
 ```
 
+#### [expect_table_column_count_to_equal_other_table_times_factor](macros/schema_tests/table_shape/expect_table_column_count_to_equal_other_table_times_factor.sql)
+
+Expect the number of columns in a model to match another model times a preconfigured factor.
+
+*Applies to:* Model, Seed, Source
+
+```yaml
+models: # or seeds:
+  - name: my_model
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal_other_table_times_factor:
+        compare_model: ref("other_model")
+        factor: 13
+```
+
 #### [expect_table_column_count_to_equal](macros/schema_tests/table_shape/expect_table_column_count_to_equal.sql)
 
 Expect the number of columns in a model to be equal to `expected_number_of_columns`.

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -130,6 +130,9 @@ models:
             column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null"]
         - dbt_expectations.expect_table_column_count_to_equal_other_table:
             compare_model: ref("data_test")
+        - dbt_expectations.expect_table_column_count_to_equal_other_table_times_factor:
+            compare_model: ref("data_test")
+            factor: 1
         - dbt_expectations.expression_is_true:
             expression: (col_numeric_a + col_numeric_b = 1)
         - dbt_expectations.equal_expression:

--- a/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table _times_factor.sql
+++ b/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table _times_factor.sql
@@ -1,0 +1,3 @@
+{%- macro test_expect_table_row_count_to_equal_other_table(model, compare_model, factor) -%}
+{{ dbt_expectations.test_equal_expression(model, "count(*)", compare_model=compare_model, compare_expression="count(*) *" + factor) }}
+{%- endmacro -%}


### PR DESCRIPTION
Hi

We have a use case where we have a table a and we want to validate that table b always has a row count that is equal to the rowcount in the table times a predefined factor.