### PR TITLE
Add expect_table_column_count_to_equal_other_table_times_factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ models: # or seeds:
         compare_model: ref("other_model")
 ```
 
+#### [expect_table_row_count_to_equal_other_table_times_factor](macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table_times_factor.sql)
+
+Expect the number of rows in a model to match another model times a preconfigured factor.
+
+*Applies to:* Model, Seed, Source
+
+```yaml
+models: # or seeds:
+  - name: my_model
+    tests:
+    - dbt_expectations.expect_table_column_count_to_equal_other_table_times_factor:
+        compare_model: ref("other_model")
+        factor: 13
+```
+
 #### [expect_table_row_count_to_equal](macros/schema_tests/table_shape/expect_table_row_count_to_equal.sql)
 
 Expect the number of rows in a model to be equal to `expected_number_of_rows`.

--- a/integration_tests/models/schema_tests/data_test_factored.sql
+++ b/integration_tests/models/schema_tests/data_test_factored.sql
@@ -1,0 +1,1 @@
+{{ dbt_utils.generate_series(upper_bound=8) }}

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -117,9 +117,6 @@ models:
             max_value: 4
         - dbt_expectations.expect_table_row_count_to_equal_other_table:
             compare_model: ref("data_test")
-        - dbt_expectations.expect_table_row_count_to_equal_other_table_times_factor:
-            compare_model: ref("data_test")
-            factor: 1
         - dbt_expectations.expect_table_column_count_to_equal:
             value: 7
         - dbt_expectations.expect_table_column_count_to_be_between:
@@ -243,3 +240,9 @@ models:
       - name: col_null
         tests:
           - dbt_expectations.expect_column_values_to_be_null
+
+  - name : data_test_factored
+    tests :
+        - dbt_expectations.expect_table_row_count_to_equal_other_table_times_factor:
+            compare_model: ref("data_test")
+            factor: 2

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -117,6 +117,9 @@ models:
             max_value: 4
         - dbt_expectations.expect_table_row_count_to_equal_other_table:
             compare_model: ref("data_test")
+        - dbt_expectations.expect_table_row_count_to_equal_other_table_times_factor:
+            compare_model: ref("data_test")
+            factor: 1
         - dbt_expectations.expect_table_column_count_to_equal:
             value: 7
         - dbt_expectations.expect_table_column_count_to_be_between:

--- a/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table _times_factor.sql
+++ b/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table _times_factor.sql
@@ -1,0 +1,3 @@
+{%- macro test_expect_table_row_count_to_equal_other_table_times_factor(model, compare_model, factor) -%}
+{{ dbt_expectations.test_equal_expression(model, "count(*)", compare_model=compare_model, compare_expression="count(*) * " + factor|string) }}
+{%- endmacro -%}


### PR DESCRIPTION
Hi

We have a use case where we have a table a and we want to validate that table b always has a row count that is equal to the row count in table a times a predefined factor.