### PR TITLE
Add initial Postgres support

### DIFF
--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -23,7 +23,7 @@ require-dbt-version: ">=0.18.1"
 
 vars:
     'dbt_date:time_zone': 'America/Los_Angeles'
-    dbt_utils_dispatch_list: [spark_utils]
+    dbt_utils_dispatch_list: [spark_utils, dbt_expectations_integration_tests]
 
 quoting:
     database: false

--- a/integration_tests/macros/datatypes.sql
+++ b/integration_tests/macros/datatypes.sql
@@ -1,0 +1,3 @@
+{% macro postgres__type_timestamp() -%}
+    timestamp without time zone
+{%- endmacro %}

--- a/integration_tests/macros/datatypes.sql
+++ b/integration_tests/macros/datatypes.sql
@@ -1,3 +1,0 @@
-{% macro postgres__type_timestamp() -%}
-    timestamp without time zone
-{%- endmacro %}

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -35,7 +35,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: date
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, TIMESTAMP WITHOUT TIME ZONE]
+              column_type_list: [date, "{{ dbt_expectations.type_datetime() | trim }}"]
           - dbt_expectations.expect_column_values_to_be_increasing:
               sort_column: date_day
 
@@ -62,7 +62,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: date
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, "{{ dbt_utils.type_timestamp() | trim }}"]
+              column_type_list: [date, "{{ dbt_expectations.type_datetime() | trim }}"]
 
       - name: row_value
         tests:
@@ -77,7 +77,7 @@ models:
       - name: row_value_log
         tests:
           - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
-              date_column_name: cast(date_day as {{ dbt_utils.type_timestamp() }})
+              date_column_name: cast(date_day as {{ dbt_expectations.type_datetime() }})
               sigma_threshold: 6
               take_logs: false
 
@@ -91,13 +91,13 @@ models:
           # - dbt_expectations.expect_column_values_to_be_of_type:
           #     column_type: datetime
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: ["{{ dbt_utils.type_timestamp() | trim }}"]
+              column_type_list: ["{{ dbt_expectations.type_datetime() | trim }}"]
 
 
       - name: row_value_log
         tests:
           - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
-              date_column_name: cast(date_hour as {{ dbt_utils.type_timestamp() }})
+              date_column_name: cast(date_hour as {{ dbt_expectations.type_datetime() }})
               period: hour
               trend_periods: 48
               test_periods: 12

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -35,7 +35,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: date
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime]
+              column_type_list: [date, TIMESTAMP WITHOUT TIME ZONE]
           - dbt_expectations.expect_column_values_to_be_increasing:
               sort_column: date_day
 
@@ -62,7 +62,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: date
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime]
+              column_type_list: [date, "{{ dbt_utils.type_timestamp() | trim }}"]
 
       - name: row_value
         tests:
@@ -77,7 +77,7 @@ models:
       - name: row_value_log
         tests:
           - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
-              date_column_name: cast(date_day as datetime)
+              date_column_name: cast(date_day as {{ dbt_utils.type_timestamp() }})
               sigma_threshold: 6
               take_logs: false
 
@@ -91,13 +91,13 @@ models:
           # - dbt_expectations.expect_column_values_to_be_of_type:
           #     column_type: datetime
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, datetime, timestamp_ntz]
+              column_type_list: ["{{ dbt_utils.type_timestamp() | trim }}"]
 
 
       - name: row_value_log
         tests:
           - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
-              date_column_name: cast(date_hour as datetime)
+              date_column_name: cast(date_hour as {{ dbt_utils.type_timestamp() }})
               period: hour
               trend_periods: 48
               test_periods: 12

--- a/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
@@ -12,7 +12,7 @@ row_values as (
 add_row_values as (
 
     select
-        cast(d.date_hour as datetime) as date_hour,
+        cast(d.date_hour as {{ dbt_utils.type_timestamp() }}) as date_hour,
         cast(floor(100 * r.generated_number) as {{ dbt_utils.type_int() }}) as row_value
     from
         dates d

--- a/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
@@ -12,7 +12,7 @@ row_values as (
 add_row_values as (
 
     select
-        cast(d.date_hour as {{ dbt_utils.type_timestamp() }}) as date_hour,
+        cast(d.date_hour as {{ dbt_expectations.type_datetime() }}) as date_hour,
         cast(floor(100 * r.generated_number) as {{ dbt_utils.type_int() }}) as row_value
     from
         dates d

--- a/macros/math/rand.sql
+++ b/macros/math/rand.sql
@@ -19,3 +19,9 @@
     uniform(0::float, 1::float, random())
 
 {%- endmacro -%}
+
+{% macro postgres__rand() %}
+
+    random()
+
+{%- endmacro -%}

--- a/macros/regex/regexp_instr.sql
+++ b/macros/regex/regexp_instr.sql
@@ -10,6 +10,12 @@
 regexp_instr({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }})
 {% endmacro %}
 
+
+{% macro postgres__regexp_instr(source_value, regexp, position, occurrence) %}
+array_length((select regexp_matches({{ source_value }}, '{{ regexp }}')), 1)
+{% endmacro %}
+
+
 {% macro spark__regexp_instr(source_value, regexp, position, occurrence) %}
 case when {{ source_value }} rlike '{{ regexp }}' then 1 else 0 end
 {% endmacro %}

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -8,7 +8,8 @@
     {%- set matching_column_types = [] -%}
 
     {%- for column in columns_in_relation -%}
-        {%- if ((column.name | upper ) == column_name) and ((column.dtype | upper ) in column_type_list) -%}
+            {{ log(column ~ ": " ~ (column.dtype | upper) ~ " - " ~ column_type_list | list ~ " - " ~ ((column.dtype | upper ) in column_type_list), info=true)}}
+        {%- if ((column.name | upper ) == column_name) and ((column.dtype | upper ) in (column_type_list | list)) -%}
             {%- do matching_column_types.append(column.name) -%}
         {%- endif -%}
     {%- endfor -%}

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -3,13 +3,12 @@
 
     {%- set column_name = column_name | upper -%}
     {%- set columns_in_relation = adapter.get_columns_in_relation(model) -%}
-    {%- set column_type_list = column_type_list| map("upper") -%}
+    {%- set column_type_list = column_type_list| map("upper") | list -%}
 
     {%- set matching_column_types = [] -%}
 
     {%- for column in columns_in_relation -%}
-            {{ log(column ~ ": " ~ (column.dtype | upper) ~ " - " ~ column_type_list | list ~ " - " ~ ((column.dtype | upper ) in column_type_list), info=true)}}
-        {%- if ((column.name | upper ) == column_name) and ((column.dtype | upper ) in (column_type_list | list)) -%}
+        {%- if ((column.name | upper ) == column_name) and ((column.dtype | upper ) in column_type_list) -%}
             {%- do matching_column_types.append(column.name) -%}
         {%- endif -%}
     {%- endfor -%}

--- a/macros/utils/datatypes.sql
+++ b/macros/utils/datatypes.sql
@@ -1,0 +1,21 @@
+{% macro postgres__type_timestamp() -%}
+    timestamp without time zone
+{%- endmacro %}
+
+
+{%- macro type_datetime() -%}
+  {{ return(adapter.dispatch('type_datetime', packages = dbt_expectations._get_namespaces())()) }}
+{%- endmacro -%}
+
+{% macro default__type_datetime() -%}
+    datetime
+{%- endmacro %}
+
+{% macro snowflake__type_datetime() -%}
+{# see: https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#datetime #}
+    timestamp_ntz
+{%- endmacro %}
+
+{% macro postgres__type_datetime() -%}
+    timestamp without time zone
+{%- endmacro %}


### PR DESCRIPTION
This PR closes #39 and #38 by adding initial support to better handle datetime and timestamp types and also add support for the equivalent of `regexp_instr` for Postgres.