### PR TITLE
Adds ability to set row_condition on row_count tests

### DIFF
--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -117,6 +117,8 @@ models:
             max_value: 4
         - dbt_expectations.expect_table_row_count_to_equal_other_table:
             compare_model: ref("data_test")
+            row_condition: 1=1
+            compare_row_condition: 1=1
         - dbt_expectations.expect_table_column_count_to_equal:
             value: 7
         - dbt_expectations.expect_table_column_count_to_be_between:

--- a/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table _times_factor.sql
+++ b/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table _times_factor.sql
@@ -1,3 +1,6 @@
-{%- macro test_expect_table_row_count_to_equal_other_table_times_factor(model, compare_model, factor) -%}
-{{ dbt_expectations.test_equal_expression(model, "count(*)", compare_model=compare_model, compare_expression="count(*) * " + factor|string, return_difference=True) }}
+{%- macro test_expect_table_row_count_to_equal_other_table_times_factor(model, compare_model, factor, row_condition=None, compare_row_condition=None) -%}
+{{ dbt_expectations.test_expect_table_row_count_to_equal_other_table(model, compare_model, factor,
+    row_condition=row_condition,
+    compare_row_condition=compare_row_condition
+) }}
 {%- endmacro -%}

--- a/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table _times_factor.sql
+++ b/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table _times_factor.sql
@@ -1,5 +1,6 @@
 {%- macro test_expect_table_row_count_to_equal_other_table_times_factor(model, compare_model, factor, row_condition=None, compare_row_condition=None) -%}
-{{ dbt_expectations.test_expect_table_row_count_to_equal_other_table(model, compare_model, factor,
+{{ dbt_expectations.test_expect_table_row_count_to_equal_other_table(model, compare_model,
+    factor=factor,
     row_condition=row_condition,
     compare_row_condition=compare_row_condition
 ) }}

--- a/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table.sql
+++ b/macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table.sql
@@ -1,3 +1,9 @@
-{%- macro test_expect_table_row_count_to_equal_other_table(model, compare_model) -%}
-{{ dbt_expectations.test_equal_expression(model, "count(*)", compare_model=compare_model, return_difference=True) }}
+{%- macro test_expect_table_row_count_to_equal_other_table(model, compare_model, factor=1, row_condition=None, compare_row_condition=None) -%}
+{{ dbt_expectations.test_equal_expression(model, "count(*)",
+    compare_model=compare_model,
+    compare_expression="count(*) * " + factor|string,
+    row_condition=row_condition,
+    compare_row_condition=compare_row_condition,
+    return_difference=True
+) }}
 {%- endmacro -%}


### PR DESCRIPTION
Closes #42 

Also refactors `expect_table_row_count_to_equal_other_table_times_factor` to just use `expect_table_row_count_to_equal_other_table` with a `factor` parameter (cc: @nysthee)