### PR TITLE
make integration tests TSQL compatible

### DIFF
--- a/integration_tests/models/schema_tests/series_10.sql
+++ b/integration_tests/models/schema_tests/series_10.sql
@@ -1,0 +1,1 @@
+{{ dbt_utils.generate_series(upper_bound=10) }}

--- a/integration_tests/models/schema_tests/series_4.sql
+++ b/integration_tests/models/schema_tests/series_4.sql
@@ -1,0 +1,1 @@
+{{ dbt_utils.generate_series(upper_bound=4) }}

--- a/integration_tests/models/schema_tests/timeseries_base.sql
+++ b/integration_tests/models/schema_tests/timeseries_base.sql
@@ -1,0 +1,1 @@
+{{ dbt_date.get_base_dates(n_dateparts=12, datepart='month') }}

--- a/integration_tests/models/schema_tests/timeseries_data.sql
+++ b/integration_tests/models/schema_tests/timeseries_data.sql
@@ -1,6 +1,6 @@
 with dates as (
 
-    {{ dbt_date.get_base_dates(n_dateparts=12, datepart='month') }}
+    select * from {{ ref('timeseries_base') }}
 
 ),
 add_row_values as (

--- a/integration_tests/models/schema_tests/timeseries_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_extended.sql
@@ -1,10 +1,10 @@
 with dates as (
 
-    {{ dbt_date.get_base_dates(n_dateparts=12, datepart='month') }}
+    select * from {{ ref('timeseries_base') }}
 
 ),
 row_values as (
-    {{ dbt_utils.generate_series(upper_bound=10) }}
+    select * from {{ ref('series_10') }}
 ),
 add_row_values as (
 

--- a/integration_tests/models/schema_tests/timeseries_data_grouped.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_grouped.sql
@@ -1,11 +1,11 @@
 with dates as (
-    {{ dbt_date.get_base_dates(n_dateparts=12, datepart='month') }}
+    select * from {{ ref('timeseries_base') }}
 ),
 groupings as (
-    {{ dbt_utils.generate_series(upper_bound=4) }}
+    select * from {{ ref('series_4') }}
 ),
 row_values as (
-    {{ dbt_utils.generate_series(upper_bound=10) }}
+    select * from {{ ref('series_10') }}
 ),
 add_row_values as (
 

--- a/integration_tests/models/schema_tests/timeseries_hourly.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly.sql
@@ -1,0 +1,4 @@
+{{ dbt_utils.date_spine('hour',
+    start_date=dbt_date.n_days_ago(10),
+    end_date=dbt_date.today()
+    ) }}

--- a/integration_tests/models/schema_tests/timeseries_hourly.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly.sql
@@ -1,4 +1,4 @@
 {{ dbt_utils.date_spine('hour',
     start_date=dbt_date.n_days_ago(10),
-    end_date=dbt_date.today()
+    end_date=dbt_date.tomorrow()
     ) }}

--- a/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
@@ -1,13 +1,10 @@
 with dates as (
 
-    {{ dbt_utils.date_spine('hour',
-        start_date=dbt_date.n_days_ago(10),
-        end_date=dbt_date.today()
-        ) }}
+    select * from {{ ref('timeseries_hourly') }}
 
 ),
 row_values as (
-    {{ dbt_utils.generate_series(upper_bound=10) }}
+    select * from {{ ref('series_10') }}
 ),
 add_row_values as (
 


### PR DESCRIPTION
I'm working on making a shim package for dbt-expectations inside of tsql-utils (https://github.com/dbt-msft/tsql-utils/pull/38).

TSQL doesn't  support nested CTEs, the solution is to break calls to `dbt_utils.date_spine()` out to their own models that are referenced in the first CTE of the downstream model.

I tested these changes and the models at least run, I don't expect any tests to fail.

