### PR TITLE
Removes spark-utils and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ For latest release, see [https://github.com/calogica/dbt-expectations/releases](
 
 This package includes a reference to [**dbt-date**](https://github.com/calogica/dbt-date) which in turn references [**dbt-utils**](https://github.com/fishtown-analytics/dbt-utils) so there's no need to also import dbt-utils in your local project.
 
+Note: we no longer include `spark_utils` in this package to avoid versioning conflicts. If you are running this package on non-core (Snowflake, BigQuery, Redshift, Postgres) platforms, you will need to use a package like `spark_utils` to shim macros.
+
+For example, in `packages.yml`, you will need to include the relevant package:
+
+```yaml
+  - package: fishtown-analytics/spark_utils
+    version: <latest or range>
+```
+
+And reference in the dispatch list for `dbt_utils` in `dbt_project.yml`:
+
+```yaml
+vars:
+    dbt_utils_dispatch_list: [spark_utils]
+```
+
 ### Variables
 
 The following variables need to be defined in your `dbt_project.yml` file:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -23,7 +23,7 @@ require-dbt-version: ">=0.18.1"
 
 vars:
     'dbt_date:time_zone': 'America/Los_Angeles'
-    dbt_utils_dispatch_list: [spark_utils, dbt_expectations_integration_tests]
+    dbt_utils_dispatch_list: [dbt_expectations_integration_tests]
 
 quoting:
     database: false

--- a/packages.yml
+++ b/packages.yml
@@ -1,5 +1,3 @@
 packages:
   - package: calogica/dbt_date
     version: [">=0.2.0", "<0.3.0"]
-  - package: fishtown-analytics/spark_utils
-    version: [">=0.1.0", "<0.2.0"]


### PR DESCRIPTION
Fixes #56 (hopefully!)

Removes dependency on spark-utils.

Users running this package on non-core (Snowflake, BigQuery, Redshift, Postgres) platforms, will need to use a package like `spark_utils` to shim macros.

For example, in `dbt_project.yml`:

```yaml
vars:
    dbt_utils_dispatch_list: [spark_utils]
```