### PR TITLE
Refactor get_select() to make grouping more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Expect the model to have rows that are at least as recent as the defined interva
 
 ```yaml
 tests:
-  - dbt_expectations.expect_table_column_count_to_be_between:
+  - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
         interval: 1
 ```

--- a/macros/schema_tests/_generalized/equal_expression.sql
+++ b/macros/schema_tests/_generalized/equal_expression.sql
@@ -4,9 +4,11 @@
 
 {%- macro default__get_select(model, expression, row_condition, group_by) %}
     select
+        {% if group_by %}
         {% for g in group_by -%}
             {{ g }} as col_{{ loop.index }},
         {% endfor -%}
+        {% endif %}
         {{ expression }} as expression
     from
         {{ model }}
@@ -14,17 +16,19 @@
     where
         {{ row_condition }}
     {% endif %}
+    {% if group_by %}
     group by
         {% for g in group_by -%}
             {{ loop.index }}{% if not loop.last %},{% endif %}
         {% endfor %}
+    {% endif %}
 {% endmacro -%}
 
 
 {% macro test_equal_expression(model, expression,
                                 compare_model=None,
                                 compare_expression=None,
-                                group_by=["'col'"],
+                                group_by=None,
                                 compare_group_by=None,
                                 row_condition=None,
                                 compare_row_condition=None,
@@ -63,7 +67,7 @@
     {%- set compare_row_condition = row_condition if not compare_row_condition else compare_row_condition -%}
     {%- set compare_group_by = group_by if not compare_group_by else compare_group_by -%}
 
-    {%- set n_cols = group_by|length %}
+    {%- set n_cols = (group_by|length) if group_by else 0 %}
     with a as (
         {{ dbt_expectations.get_select(model, expression, row_condition, group_by) }}
     ),
@@ -82,12 +86,16 @@
             abs(coalesce(a.expression, 0) - coalesce(b.expression, 0))/
                 nullif(a.expression * 1.0, 0) as expression_difference_percent
         from
+        {% if n_cols > 0 %}
             a
             full outer join
             b on
             {% for i in range(1, n_cols + 1) -%}
                 a.col_{{ i }} = b.col_{{ i }} {% if not loop.last %}and{% endif %}
             {% endfor -%}
+        {% else %}
+            a cross join b
+        {% endif %}
     )
     -- DEBUG:
     -- select * from final


### PR DESCRIPTION
Initial take on making `get_select` in `equal_expression` more explicit. 
Closes #62 