### PR TITLE
Add support for optional min/max to between tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ Expect the number of columns in a model to be between two values.
 ```yaml
 tests:
   - dbt_expectations.expect_table_column_count_to_be_between:
-      min_value: 1
-      max_value: 4
+      min_value: 1 # (Optional)
+      max_value: 4 # (Optional)
 ```
 
 ### [expect_table_column_count_to_equal_other_table](macros/schema_tests/table_shape/expect_table_column_count_to_equal_other_table.sql)
@@ -267,7 +267,6 @@ models: # or seeds:
 ### [expect_table_row_count_to_be_between](macros/schema_tests/table_shape/expect_table_row_count_to_be_between.sql)
 
 Expect the number of rows in a model to be between two values.
-
 *Applies to:* Model, Seed, Source
 
 ```yaml
@@ -275,8 +274,8 @@ models: # or seeds:
   - name: my_model
     tests:
     - dbt_expectations.expect_table_row_count_to_be_between:
-        min_value: 1
-        max_value: 4
+        min_value: 1 # (Optional)
+        max_value: 4 # (Optional)
 ```
 
 ### [expect_table_row_count_to_equal_other_table](macros/schema_tests/table_shape/expect_table_row_count_to_equal_other_table.sql)
@@ -400,8 +399,8 @@ Expect each column value to be between two values.
 ```yaml
 tests:
   - dbt_expectations.expect_column_values_to_be_between:
-      min_value: 0
-      max_value: 10
+      min_value: 0  # (Optional)
+      max_value: 10 # (Optional)
 ```
 
 ### [expect_column_values_to_not_be_in_set](macros/schema_tests/column_values_basic/expect_column_values_to_not_be_in_set.sql)
@@ -454,8 +453,8 @@ Expect column entries to be strings with length between a min_value value and a 
 ```yaml
 tests:
   - dbt_expectations.expect_column_value_lengths_to_be_between:
-      min_value: 1
-      max_value: 4
+      min_value: 1 # (Optional)
+      max_value: 4 # (Optional)
 ```
 
 ### [expect_column_value_lengths_to_equal](macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql)
@@ -672,8 +671,8 @@ Expect the column mean to be between a min_value value and a max_value value (in
 ```yaml
 tests:
   - dbt_expectations.expect_column_mean_to_be_between:
-      min_value: 0
-      max_value: 2
+      min_value: 0 # (Optional)
+      max_value: 2 # (Optional)
 ```
 
 ### [expect_column_median_to_be_between](macros/schema_tests/aggregate_functions/expect_column_median_to_be_between.sql)
@@ -699,8 +698,8 @@ Expect specific provided column quantiles to be between provided min_value and m
 tests:
   - dbt_expectations.expect_column_quantile_values_to_be_between:
       quantile: .95
-      min_value: 0
-      max_value: 2
+      min_value: 0 # (Optional)
+      max_value: 2 # (Optional)
 ```
 
 ### [expect_column_stdev_to_be_between](macros/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql)
@@ -712,8 +711,8 @@ Expect the column standard deviation to be between a min_value value and a max_v
 ```yaml
 tests:
   - dbt_expectations.expect_column_stdev_to_be_between:
-      min_value: 0
-      max_value: 2
+      min_value: 0 # (Optional)
+      max_value: 2 # (Optional)
 ```
 
 ### [expect_column_unique_value_count_to_be_between](macros/schema_tests/aggregate_functions/expect_column_unique_value_count_to_be_between.sql)
@@ -725,8 +724,8 @@ Expect the number of unique values to be between a min_value value and a max_val
 ```yaml
 tests:
   - dbt_expectations.expect_column_unique_value_count_to_be_between:
-      min_value: 3
-      max_value: 3
+      min_value: 3 # (Optional)
+      max_value: 3 # (Optional)
 ```
 
 ### [expect_column_proportion_of_unique_values_to_be_between](macros/schema_tests/aggregate_functions/expect_column_proportion_of_unique_values_to_be_between.sql)
@@ -740,8 +739,8 @@ For example, in a column containing [1, 2, 2, 3, 3, 3, 4, 4, 4, 4], there are 4 
 ```yaml
 tests:
   - dbt_expectations.expect_column_proportion_of_unique_values_to_be_between:
-      min_value: 0
-      max_value: .4
+      min_value: 0  # (Optional)
+      max_value: .4 # (Optional)
 ```
 
 ### [expect_column_most_common_value_to_be_in_set](macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql)
@@ -766,8 +765,8 @@ Expect the column max to be between a min and max value
 ```yaml
 tests:
   - dbt_expectations.expect_column_max_to_be_between:
-      min_value: 1
-      max_value: 1
+      min_value: 1 # (Optional)
+      max_value: 1 # (Optional)
 ```
 
 ### [expect_column_min_to_be_between](macros/schema_tests/aggregate_functions/expect_column_min_to_be_between.sql)
@@ -779,8 +778,8 @@ Expect the column min to be between a min and max value
 ```yaml
 tests:
   - dbt_expectations.expect_column_min_to_be_between:
-      min_value: 0
-      max_value: 1
+      min_value: 0 # (Optional)
+      max_value: 1 # (Optional)
 ```
 
 ### [expect_column_sum_to_be_between](macros/schema_tests/aggregate_functions/expect_column_sum_to_be_between.sql)
@@ -792,8 +791,8 @@ Expect the column to sum to be between a min and max value
 ```yaml
 tests:
   - dbt_expectations.expect_column_sum_to_be_between:
-      min_value: 1
-      max_value: 2
+      min_value: 1 # (Optional)
+      max_value: 2 # (Optional)
 ```
 
 ### [expect_column_pair_values_A_to_be_greater_than_B](macros/schema_tests/multi-column/expect_column_pair_values_A_to_be_greater_than_B.sql)

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -125,6 +125,10 @@ models:
         - dbt_expectations.expect_table_row_count_to_be_between:
             min_value: 1
             max_value: 4
+        - dbt_expectations.expect_table_row_count_to_be_between:
+            min_value: 1
+        - dbt_expectations.expect_table_row_count_to_be_between:
+            max_value: 4
         - dbt_expectations.expect_table_row_count_to_equal_other_table:
             compare_model: ref("data_test")
             row_condition: 1=1
@@ -133,6 +137,10 @@ models:
             value: 7
         - dbt_expectations.expect_table_column_count_to_be_between:
             min_value: 1
+            max_value: 10
+        - dbt_expectations.expect_table_column_count_to_be_between:
+            min_value: 1
+        - dbt_expectations.expect_table_column_count_to_be_between:
             max_value: 10
         - dbt_expectations.expect_table_columns_to_contain_set:
             column_list: ["col_numeric_b", "col_string_a"]

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -199,6 +199,8 @@ models:
           - dbt_expectations.expect_column_values_to_be_between:
               min_value: 0
               max_value: 1
+          - dbt_expectations.expect_column_values_to_be_between:
+              min_value: 0
           - dbt_expectations.expect_column_sum_to_be_between:
               min_value: 1
               max_value: 3

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -256,6 +256,10 @@ models:
           - dbt_expectations.expect_column_value_lengths_to_be_between:
               min_value: 1
               max_value: 4
+          - dbt_expectations.expect_column_value_lengths_to_be_between:
+              min_value: 1
+          - dbt_expectations.expect_column_value_lengths_to_be_between:
+              max_value: 4
 
       - name: col_null
         tests:

--- a/macros/schema_tests/_generalized/expression_between.sql
+++ b/macros/schema_tests/_generalized/expression_between.sql
@@ -1,7 +1,7 @@
 {% macro test_expression_between(model,
                                  expression,
-                                 min_value,
-                                 max_value,
+                                 min_value=None,
+                                 max_value=None,
                                  row_condition=None
                                  ) %}
 
@@ -16,9 +16,17 @@
                             row_condition
                             ) %}
 
+{%- if min_value is none and max_value is none -%}
+{{ exceptions.raise_compiler_error(
+    "You have to provide either a min_value, max_value or both."
+) }}
+
+{%- endif -%}
 {% set expression %}
-{{ expression }} >= {{ min_value }} and
-{{ expression }} <= {{ max_value }}
+( 1=1
+{%- if min_value is not none %} and {{ expression }} >= {{ min_value }}{% endif %}
+{%- if max_value is not none %} and {{ expression }} <= {{ max_value }}{% endif %}
+)
 {% endset %}
 
 {{ dbt_expectations.expression_is_true(model,

--- a/macros/schema_tests/_generalized/expression_between.sql
+++ b/macros/schema_tests/_generalized/expression_between.sql
@@ -20,9 +20,8 @@
 {{ exceptions.raise_compiler_error(
     "You have to provide either a min_value, max_value or both."
 ) }}
-
 {%- endif -%}
-{% set expression %}
+{% set expression_min_max %}
 ( 1=1
 {%- if min_value is not none %} and {{ expression }} >= {{ min_value }}{% endif %}
 {%- if max_value is not none %} and {{ expression }} <= {{ max_value }}{% endif %}
@@ -30,7 +29,7 @@
 {% endset %}
 
 {{ dbt_expectations.expression_is_true(model,
-                                        expression=expression,
+                                        expression=expression_min_max,
                                         row_condition=row_condition)
                                         }}
 

--- a/macros/schema_tests/aggregate_functions/expect_column_max_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_max_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_max_to_be_between(model, column_name,
-                                                min_value,
-                                                max_value,
+                                                min_value=None,
+                                                max_value=None,
                                                 row_condition=None
                                                 ) %}
 {% set expression %}

--- a/macros/schema_tests/aggregate_functions/expect_column_mean_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_mean_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_mean_to_be_between(model, column_name,
-                                                    min_value,
-                                                    max_value,
+                                                    min_value=None,
+                                                    max_value=None,
                                                     row_condition=None
                                                     ) %}
 {% set expression %}

--- a/macros/schema_tests/aggregate_functions/expect_column_median_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_median_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_median_to_be_between(model, column_name,
-                                                    min_value,
-                                                    max_value,
+                                                    min_value=None,
+                                                    max_value=None,
                                                     row_condition=None
                                                     ) %}
 

--- a/macros/schema_tests/aggregate_functions/expect_column_min_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_min_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_min_to_be_between(model, column_name,
-                                                    min_value,
-                                                    max_value,
+                                                    min_value=None,
+                                                    max_value=None,
                                                     row_condition=None
                                                     ) %}
 {% set expression %}

--- a/macros/schema_tests/aggregate_functions/expect_column_proportion_of_unique_values_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_proportion_of_unique_values_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_proportion_of_unique_values_to_be_between(model, column_name,
-                                                            min_value,
-                                                            max_value,
+                                                            min_value=None,
+                                                            max_value=None,
                                                             row_condition=None
                                                             ) %}
 {% set expression %}

--- a/macros/schema_tests/aggregate_functions/expect_column_quantile_values_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_quantile_values_to_be_between.sql
@@ -1,7 +1,7 @@
 {% macro test_expect_column_quantile_values_to_be_between(model, column_name,
                                                             quantile,
-                                                            min_value,
-                                                            max_value,
+                                                            min_value=None,
+                                                            max_value=None,
                                                             row_condition=None
                                                             ) %}
 

--- a/macros/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_stdev_to_be_between(model, column_name,
-                                                    min_value,
-                                                    max_value,
+                                                    min_value=None,
+                                                    max_value=None,
                                                     row_condition=None
                                                     ) -%}
     {{ adapter.dispatch('test_expect_column_stdev_to_be_between', packages = dbt_expectations._get_namespaces()) (model, column_name,

--- a/macros/schema_tests/aggregate_functions/expect_column_sum_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_sum_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_sum_to_be_between(model, column_name,
-                                                min_value,
-                                                max_value,
+                                                min_value=None,
+                                                max_value=None,
                                                 row_condition=None
                                                 ) %}
 {% set expression %}

--- a/macros/schema_tests/aggregate_functions/expect_column_unique_value_count_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_unique_value_count_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_unique_value_count_to_be_between(model, column_name,
-                                                            min_value,
-                                                            max_value,
+                                                            min_value=None,
+                                                            max_value=None,
                                                             row_condition=None
                                                             ) %}
 {% set expression %}

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_between.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_between.sql
@@ -1,6 +1,6 @@
 {% macro test_expect_column_values_to_be_between(model, column_name,
-                                                   min_value,
-                                                   max_value,
+                                                   min_value=None,
+                                                   max_value=None,
                                                    row_condition=None
                                                    ) %}
 

--- a/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
+++ b/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
@@ -1,18 +1,17 @@
 {% macro test_expect_column_value_lengths_to_be_between(model, column_name,
-                                                         min_value,
-                                                         max_value,
+                                                         min_value=None,
+                                                         max_value=None,
                                                          row_condition=None
                                                       ) %}
 {% set expression %}
-{{ dbt_utils.length(column_name) ~ " >= " ~ min_value ~ " or " ~
-   dbt_utils.length(column_name) ~ " <= " ~ max_value }}
+{{ dbt_utils.length(column_name) }}
 {% endset %}
 
-{{ dbt_expectations.expression_is_true(model,
+{{ dbt_expectations.expression_between(model,
                                         expression=expression,
+                                        min_value=min_value,
+                                        max_value=max_value,
                                         row_condition=row_condition
-                                        )
-                                        }}
-
+                                        ) }}
 
 {% endmacro %}

--- a/macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql
+++ b/macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql
@@ -1,9 +1,26 @@
-{%- macro test_expect_table_column_count_to_be_between(model, min_value, max_value) -%}
+{%- macro test_expect_table_column_count_to_be_between(model,
+                                                        min_value=None,
+                                                        max_value=None
+                                                        ) -%}
+{%- if min_value is none and max_value is none -%}
+{{ exceptions.raise_compiler_error(
+    "You have to provide either a min_value, max_value or both."
+) }}
+{%- endif -%}
 {%- if execute -%}
 {%- set number_actual_columns = (adapter.get_columns_in_relation(model) | length) -%}
+
+{%- set expression %}
+( 1=1
+{%- if min_value is not none %} and {{ number_actual_columns }} >= {{ min_value }}{% endif %}
+{%- if max_value is not none %} and {{ number_actual_columns }} <= {{ max_value }}{% endif %}
+)
+{% endset -%}
+
 select
     case
-        when {{ number_actual_columns }} >= {{ min_value }} and {{ number_actual_columns }} <= {{ max_value }}
+        when
+            {{ expression }}
         then 0 else 1
     end
 {%- endif -%}

--- a/macros/schema_tests/table_shape/expect_table_row_count_to_be_between.sql
+++ b/macros/schema_tests/table_shape/expect_table_row_count_to_be_between.sql
@@ -1,6 +1,6 @@
 {%- macro test_expect_table_row_count_to_be_between(model,
-                                                      min_value,
-                                                      max_value,
+                                                      min_value=None,
+                                                      max_value=None,
                                                       row_condition=None
                                                     ) -%}
 {% set expression %}


### PR DESCRIPTION
This adds support for optional min/max values to most `between` type tests:

e.g.:
```yaml
- dbt_expectations.expect_column_values_to_be_between:
       min_value: 0
```
Would essentially translate to `>=0`
