### PR TITLE
Add support for group_by to expression tests

### DIFF
--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -281,6 +281,14 @@ models:
 
   - name : timeseries_data_grouped
     tests :
+        - dbt_expectations.expect_table_row_count_to_be_between:
+            min_value: 10
+        - dbt_expectations.expect_table_row_count_to_be_between:
+            min_value: 10
+            group_by: [date_day]
+        - dbt_expectations.expect_table_row_count_to_be_between:
+            max_value: 10000
+            group_by: [group_id]
         - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
             group_by: [group_id]
             timestamp_column: date_day

--- a/macros/schema_tests/_generalized/expression_between.sql
+++ b/macros/schema_tests/_generalized/expression_between.sql
@@ -2,10 +2,11 @@
                                  expression,
                                  min_value=None,
                                  max_value=None,
+                                 group_by_columns=None,
                                  row_condition=None
                                  ) %}
 
-    {{ dbt_expectations.expression_between(model, expression, min_value, max_value, row_condition) }}
+    {{ dbt_expectations.expression_between(model, expression, min_value, max_value, group_by_columns, row_condition) }}
 
 {% endmacro %}
 
@@ -13,6 +14,7 @@
                             expression,
                             min_value,
                             max_value,
+                            group_by_columns,
                             row_condition
                             ) %}
 
@@ -23,13 +25,14 @@
 {%- endif -%}
 {% set expression_min_max %}
 ( 1=1
-{%- if min_value is not none %} and {{ expression }} >= {{ min_value }}{% endif %}
-{%- if max_value is not none %} and {{ expression }} <= {{ max_value }}{% endif %}
+{%- if min_value %} and {{ expression }} >= {{ min_value }}{% endif %}
+{%- if max_value %} and {{ expression }} <= {{ max_value }}{% endif %}
 )
 {% endset %}
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression_min_max,
+                                        group_by_columns=group_by_columns,
                                         row_condition=row_condition)
                                         }}
 

--- a/macros/schema_tests/_generalized/expression_is_true.sql
+++ b/macros/schema_tests/_generalized/expression_is_true.sql
@@ -18,11 +18,8 @@
     {{ adapter.dispatch('expression_is_true', packages = dbt_expectations._get_namespaces()) (model, expression, test_condition, group_by_columns, row_condition) }}
 {%- endmacro %}
 
-{% macro default__expression_is_true(model, expression, test_condition, group_by_columns, row_condition) %}
-
-
+{% macro default__expression_is_true(model, expression, test_condition, group_by_columns, row_condition) -%}
 with grouped_expression as (
-
     select
         {% if group_by_columns %}
         {% for group_by_column in group_by_columns -%}
@@ -57,4 +54,4 @@ validation_errors as (
 select count(*)
 from validation_errors
 
-{% endmacro %}
+{% endmacro -%}

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_greater_than.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_greater_than.sql
@@ -2,6 +2,7 @@
                                                                 column_name,
                                                                 value,
                                                                 quote_values=False,
+                                                                group_by=None,
                                                                 row_condition=None
                                                                 ) %}
 {% set expression %}
@@ -9,6 +10,7 @@ count(distinct {{ column_name }}) > {{ value }}
 {% endset %}
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition)
                                         }}
 {%- endmacro -%}

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql
@@ -2,6 +2,7 @@
                                                     column_name,
                                                     value,
                                                     quote_values=False,
+                                                    group_by=None,
                                                     row_condition=None
                                                     ) %}
 {% set expression %}
@@ -9,6 +10,7 @@ count(distinct {{ column_name }}) = {{ value }}
 {% endset %}
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition)
                                         }}
 {%- endmacro -%}

--- a/macros/schema_tests/aggregate_functions/expect_column_max_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_max_to_be_between.sql
@@ -1,6 +1,7 @@
 {% macro test_expect_column_max_to_be_between(model, column_name,
                                                 min_value=None,
                                                 max_value=None,
+                                                group_by=None,
                                                 row_condition=None
                                                 ) %}
 {% set expression %}
@@ -10,6 +11,7 @@ max({{ column_name }})
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 {% endmacro %}

--- a/macros/schema_tests/aggregate_functions/expect_column_mean_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_mean_to_be_between.sql
@@ -1,6 +1,7 @@
 {% macro test_expect_column_mean_to_be_between(model, column_name,
                                                     min_value=None,
                                                     max_value=None,
+                                                    group_by=None,
                                                     row_condition=None
                                                     ) %}
 {% set expression %}
@@ -10,6 +11,7 @@ avg({{ column_name }})
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 {% endmacro %}

--- a/macros/schema_tests/aggregate_functions/expect_column_median_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_median_to_be_between.sql
@@ -1,6 +1,7 @@
 {% macro test_expect_column_median_to_be_between(model, column_name,
                                                     min_value=None,
                                                     max_value=None,
+                                                    group_by=None,
                                                     row_condition=None
                                                     ) %}
 
@@ -11,6 +12,7 @@
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 {% endmacro %}

--- a/macros/schema_tests/aggregate_functions/expect_column_min_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_min_to_be_between.sql
@@ -1,6 +1,7 @@
 {% macro test_expect_column_min_to_be_between(model, column_name,
                                                     min_value=None,
                                                     max_value=None,
+                                                    group_by=None,
                                                     row_condition=None
                                                     ) %}
 {% set expression %}
@@ -10,6 +11,7 @@ min({{ column_name }})
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 

--- a/macros/schema_tests/aggregate_functions/expect_column_proportion_of_unique_values_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_proportion_of_unique_values_to_be_between.sql
@@ -1,6 +1,7 @@
 {% macro test_expect_column_proportion_of_unique_values_to_be_between(model, column_name,
                                                             min_value=None,
                                                             max_value=None,
+                                                            group_by=None,
                                                             row_condition=None
                                                             ) %}
 {% set expression %}
@@ -10,6 +11,7 @@ count(distinct {{ column_name }})/count({{ column_name }})
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 

--- a/macros/schema_tests/aggregate_functions/expect_column_quantile_values_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_quantile_values_to_be_between.sql
@@ -2,6 +2,7 @@
                                                             quantile,
                                                             min_value=None,
                                                             max_value=None,
+                                                            group_by=None,
                                                             row_condition=None
                                                             ) %}
 
@@ -12,6 +13,7 @@
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 {% endmacro %}

--- a/macros/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_stdev_to_be_between.sql
@@ -1,11 +1,13 @@
 {% macro test_expect_column_stdev_to_be_between(model, column_name,
                                                     min_value=None,
                                                     max_value=None,
+                                                    group_by=None,
                                                     row_condition=None
                                                     ) -%}
     {{ adapter.dispatch('test_expect_column_stdev_to_be_between', packages = dbt_expectations._get_namespaces()) (model, column_name,
                                                     min_value,
                                                     max_value,
+                                                    group_by,
                                                     row_condition
                                                     ) }}
 {%- endmacro %}
@@ -13,6 +15,7 @@
 {% macro default__test_expect_column_stdev_to_be_between(model, column_name,
                                                     min_value,
                                                     max_value,
+                                                    group_by,
                                                     row_condition
                                                     ) %}
 
@@ -23,6 +26,7 @@ stddev({{ column_name }})
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 {% endmacro %}

--- a/macros/schema_tests/aggregate_functions/expect_column_sum_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_sum_to_be_between.sql
@@ -1,6 +1,7 @@
 {% macro test_expect_column_sum_to_be_between(model, column_name,
                                                 min_value=None,
                                                 max_value=None,
+                                                group_by=None,
                                                 row_condition=None
                                                 ) %}
 {% set expression %}
@@ -10,6 +11,7 @@ sum({{ column_name }})
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 {% endmacro %}

--- a/macros/schema_tests/aggregate_functions/expect_column_unique_value_count_to_be_between.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_unique_value_count_to_be_between.sql
@@ -1,6 +1,7 @@
 {% macro test_expect_column_unique_value_count_to_be_between(model, column_name,
                                                             min_value=None,
                                                             max_value=None,
+                                                            group_by=None,
                                                             row_condition=None
                                                             ) %}
 {% set expression %}
@@ -10,6 +11,7 @@ count(distinct {{ column_name }})
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 {% endmacro %}

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_between.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_between.sql
@@ -12,6 +12,7 @@
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         ) }}
 

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_null.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_null.sql
@@ -4,6 +4,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_not_be_null.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_not_be_null.sql
@@ -4,6 +4,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/multi-column/expect_column_pair_values_A_to_be_greater_than_B.sql
+++ b/macros/schema_tests/multi-column/expect_column_pair_values_A_to_be_greater_than_B.sql
@@ -11,6 +11,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/multi-column/expect_column_pair_values_to_be_equal.sql
+++ b/macros/schema_tests/multi-column/expect_column_pair_values_to_be_equal.sql
@@ -10,6 +10,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/multi-column/expect_column_pair_values_to_be_in_set.sql
+++ b/macros/schema_tests/multi-column/expect_column_pair_values_to_be_in_set.sql
@@ -19,6 +19,7 @@
 {% endset %}
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/multi-column/expect_multicolumn_sum_to_equal.sql
+++ b/macros/schema_tests/multi-column/expect_multicolumn_sum_to_equal.sql
@@ -2,6 +2,7 @@
 {% macro test_expect_multicolumn_sum_to_equal(model,
                                                 column_list,
                                                 sum_total,
+                                                group_by=None,
                                                 row_condition=None
                                                 ) %}
 
@@ -14,6 +15,7 @@ sum({{ column }}){% if not loop.last %} + {% endif %}
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
+++ b/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
@@ -11,6 +11,7 @@
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         ) }}
 

--- a/macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql
+++ b/macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql
@@ -7,6 +7,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern.sql
@@ -7,6 +7,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern_list.sql
@@ -15,6 +15,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_regex.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_regex.sql
@@ -9,6 +9,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_regex_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_regex_list.sql
@@ -15,6 +15,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern.sql
@@ -7,6 +7,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern_list.sql
@@ -15,6 +15,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex.sql
@@ -9,6 +9,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex_list.sql
@@ -15,6 +15,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql
+++ b/macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql
@@ -12,8 +12,8 @@
 
 {%- set expression %}
 ( 1=1
-{%- if min_value is not none %} and {{ number_actual_columns }} >= {{ min_value }}{% endif %}
-{%- if max_value is not none %} and {{ number_actual_columns }} <= {{ max_value }}{% endif %}
+{%- if min_value %} and {{ number_actual_columns }} >= {{ min_value }}{% endif %}
+{%- if max_value %} and {{ number_actual_columns }} <= {{ max_value }}{% endif %}
 )
 {% endset -%}
 

--- a/macros/schema_tests/table_shape/expect_table_row_count_to_be_between.sql
+++ b/macros/schema_tests/table_shape/expect_table_row_count_to_be_between.sql
@@ -1,7 +1,8 @@
 {%- macro test_expect_table_row_count_to_be_between(model,
-                                                      min_value=None,
-                                                      max_value=None,
-                                                      row_condition=None
+                                                    min_value=None,
+                                                    max_value=None,
+                                                    group_by=None,
+                                                    row_condition=None
                                                     ) -%}
 {% set expression %}
 count(*)
@@ -10,6 +11,7 @@ count(*)
                                         expression=expression,
                                         min_value=min_value,
                                         max_value=max_value,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition
                                         ) }}
 {%- endmacro -%}

--- a/macros/schema_tests/table_shape/expect_table_row_count_to_equal.sql
+++ b/macros/schema_tests/table_shape/expect_table_row_count_to_equal.sql
@@ -1,5 +1,6 @@
 {%- macro test_expect_table_row_count_to_equal(model,
                                                 value,
+                                                group_by=None,
                                                 row_condition=None
                                                 ) -%}
 {% set expression %}
@@ -7,6 +8,7 @@ count(*) = {{ value }}
 {% endset %}
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
+                                        group_by_columns=group_by,
                                         row_condition=row_condition)
                                         }}
 {%- endmacro -%}


### PR DESCRIPTION
This PR adds support for `group_by` to any tests using the `expression_is_true` and `expression_between` macros.