### PR TITLE
🔥 Fix expression_between to correctly evaluate 0s  

### DIFF
--- a/macros/schema_tests/_generalized/expression_between.sql
+++ b/macros/schema_tests/_generalized/expression_between.sql
@@ -25,8 +25,8 @@
 {%- endif -%}
 {% set expression_min_max %}
 ( 1=1
-{%- if min_value %} and {{ expression }} >= {{ min_value }}{% endif %}
-{%- if max_value %} and {{ expression }} <= {{ max_value }}{% endif %}
+{%- if min_value is not none %} and {{ expression }} >= {{ min_value }}{% endif %}
+{%- if max_value is not none %} and {{ expression }} <= {{ max_value }}{% endif %}
 )
 {% endset %}
 


### PR DESCRIPTION
Change eval to `is not none`