### PR TITLE
Add new date frequency test: expect_row_values_to_have_data_for_every_n_datepart

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,3 +906,18 @@ tests:
       group_by: date_day
       sigma_threshold: 3
 ```
+
+### [expect_row_values_to_have_data_for_every_n_datepart](macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql)
+
+Expects model to have values for every grouped `date_part`.
+
+For example, this tests whether a model has data for every `day` (grouped on `date_col`) from either a specified `start_date` and `end_date`, or for the `min`/`max` value of the specified `date_col`.
+
+*Applies to:* Model, Seed, Source
+
+```yaml
+tests:
+    - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
+        date_col: date_day
+        date_part: day
+```

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -32,6 +32,9 @@ models:
             compare_column_name: date_day
         - dbt_expectations.expect_column_distinct_count_to_equal_other_table:
             column_name: date_day
+        - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
+            date_col: date_day
+            date_part: day
 
     columns:
       - name: date_day
@@ -40,9 +43,9 @@ models:
               datepart: day
               interval: 1
           - dbt_expectations.expect_column_values_to_be_of_type:
-              column_type: date
+              column_type: "{{ dbt_expectations.type_datetime() }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, "{{ dbt_expectations.type_datetime() | trim }}"]
+              column_type_list: [date, "{{ dbt_expectations.type_datetime() }}"]
           - dbt_expectations.expect_column_values_to_be_increasing:
               sort_column: date_day
           - dbt_expectations.expect_column_distinct_count_to_equal_other_table:
@@ -62,6 +65,9 @@ models:
     tests:
         - dbt_expectations.expect_table_columns_to_match_ordered_list:
             column_list: ["date_day", "row_value", "row_value_log"]
+        - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
+            date_col: date_day
+            date_part: day
 
     columns:
       - name: date_day
@@ -70,9 +76,9 @@ models:
               datepart: day
               interval: 1
           - dbt_expectations.expect_column_values_to_be_of_type:
-              column_type: date
+              column_type: "{{ dbt_expectations.type_datetime() }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, "{{ dbt_expectations.type_datetime() | trim }}"]
+              column_type_list: [date, "{{ dbt_expectations.type_datetime() }}"]
 
       - name: row_value
         tests:
@@ -92,16 +98,21 @@ models:
               take_logs: false
 
   - name: timeseries_hourly_data_extended
+    tests:
+      - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
+          date_col: date_hour
+          date_part: hour
+
     columns:
       - name: date_hour
         tests:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: hour
               interval: 24
-          # - dbt_expectations.expect_column_values_to_be_of_type:
-          #     column_type: datetime
+          - dbt_expectations.expect_column_values_to_be_of_type:
+              column_type: "{{ dbt_expectations.type_datetime() }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: ["{{ dbt_expectations.type_datetime() | trim }}"]
+              column_type_list: ["{{ dbt_expectations.type_datetime() }}"]
 
 
       - name: row_value_log

--- a/integration_tests/models/schema_tests/timeseries_base.sql
+++ b/integration_tests/models/schema_tests/timeseries_base.sql
@@ -1,1 +1,1 @@
-{{ dbt_date.get_base_dates(n_dateparts=12, datepart='month') }}
+{{ dbt_date.get_base_dates(n_dateparts=366, datepart='day') }}

--- a/integration_tests/models/schema_tests/timeseries_data.sql
+++ b/integration_tests/models/schema_tests/timeseries_data.sql
@@ -6,7 +6,7 @@ with dates as (
 add_row_values as (
 
     select
-        d.date_day,
+        cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
         cast(abs({{ dbt_expectations.rand() }}) as {{ dbt_utils.type_float() }}) as row_value
     from
         dates d

--- a/integration_tests/models/schema_tests/timeseries_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_extended.sql
@@ -9,7 +9,7 @@ row_values as (
 add_row_values as (
 
     select
-        d.date_day,
+        cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
         cast(abs({{ dbt_expectations.rand() }}) as {{ dbt_utils.type_float() }}) as row_value
     from
         dates d

--- a/integration_tests/models/schema_tests/timeseries_data_grouped.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_grouped.sql
@@ -10,7 +10,7 @@ row_values as (
 add_row_values as (
 
     select
-        d.date_day,
+        cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
         cast(g.generated_number as {{ dbt_utils.type_int() }}) as group_id,
         cast(floor(100 * r.generated_number) as {{ dbt_utils.type_int() }}) as row_value
     from

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -7,8 +7,11 @@
 
     {%- set matching_column_types = [] -%}
 
-    {%- for column in columns_in_relation -%}
-        {%- if ((column.name | upper ) == column_name) and ((column.dtype | upper ) in column_type_list) -%}
+    -- DEBUG:
+    -- {{ model.name }}
+    {%- for column in columns_in_relation %}
+    -- {{ column.name | upper }}: {{ column.dtype | upper }} in {{ column_type_list }}?
+        {% if ((column.name | upper ) == column_name) and ((column.dtype | upper ) in column_type_list) -%}
             {%- do matching_column_types.append(column.name) -%}
         {%- endif -%}
     {%- endfor -%}

--- a/macros/utils/datatypes.sql
+++ b/macros/utils/datatypes.sql
@@ -11,8 +11,8 @@
     datetime
 {%- endmacro %}
 
-{% macro snowflake__type_datetime() -%}
 {# see: https://docs.snowflake.com/en/sql-reference/data-types-datetime.html#datetime #}
+{% macro snowflake__type_datetime() -%}
     timestamp_ntz
 {%- endmacro %}
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,4 @@
 packages:
-  - package: calogica/dbt_date
-    version: [">=0.2.0", "<0.3.0"]
+  # - package: calogica/dbt_date
+  #   version: [">=0.3.0", "<0.4.0"]
+  - local: /Users/claus/dev/calogica/dbt-date

--- a/packages.yml
+++ b/packages.yml
@@ -1,4 +1,3 @@
 packages:
-  # - package: calogica/dbt_date
-  #   version: [">=0.3.0", "<0.4.0"]
-  - local: /Users/claus/dev/calogica/dbt-date
+  - package: calogica/dbt_date
+    version: [">=0.3.0", "<0.4.0"]


### PR DESCRIPTION
This adds a new macro, `expect_row_values_to_have_data_for_every_n_datepart`, which tests whether a model has values for every grouped `date_part`.

For example, this tests whether a model has data for every `day` (grouped on `date_col`) from either a specified `start_date` and `end_date`, or for the `min`/`max` value of the specified `date_col`.


```yaml
tests:
    - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
        date_col: date_day
        date_part: day
```


