### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ models: # or seeds:
 
 Expect the number of columns in a model to be between two values.
 
-*Applies to:* Column
+*Applies to:* Model, Seed, Source
 
 ```yaml
 tests:


### PR DESCRIPTION
The readme for test "expect_table_column_count_to_be_between" changed to apply on "model/seed/source" instead of "column" (refer issue #95 for details)