### PR TITLE
Fix types in expect_table_columns_to_match_* tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dbt-expectations v0.4.0
 
+## Fixes
+* `expect_table_columns_to_match_list` remove `''` to leave columns as numbers ([#98](https://github.com/calogica/dbt-expectations/issues/98))
+
+* `expect_table_columns_to_match_ordered_list` now explicitly casts the column list to a string type ([#99](https://github.com/calogica/dbt-expectations/issues/99))
+
+# dbt-expectations v0.4.0
+
 ## Breaking Changes
 
 * Requires `dbt >= 0.20`

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
@@ -8,8 +8,8 @@
     with test_data as (
 
         select
-            '{{ ordered_column_names }}' as ordered_column_names,
-            '{{ ordered_relation_column_names }}' as ordered_relation_column_names
+            cast('{{ ordered_column_names }}' as {{ dbt_utils.type_string() }}) as ordered_column_names,
+            cast('{{ ordered_relation_column_names }}' as {{ dbt_utils.type_string() }}) as ordered_relation_column_names
 
     )
     select *

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
@@ -6,8 +6,8 @@
     with test_data as (
 
         select
-            '{{ relation_column_names | length }}' as number_columns,
-            '{{ matching_columns | length }}' as number_matching_columns
+            {{ relation_column_names | length }} as number_columns,
+            {{ matching_columns | length }} as number_matching_columns
 
     )
     select *


### PR DESCRIPTION
This hopefully fixes #98  and #99 

* For #98 this remove `''` that were inadvertently added during an earlier PR
* For #99 this explicitly casts the list of columns to a platform specific string type