### PR TITLE
Fix regexp_instr on Redshift

### DIFF
--- a/macros/regex/regexp_instr.sql
+++ b/macros/regex/regexp_instr.sql
@@ -10,6 +10,9 @@
 regexp_instr({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }})
 {% endmacro %}
 
+{% macro redshift__regexp_instr(source_value, regexp, position, occurrence) %}
+regexp_instr({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }})
+{% endmacro %}
 
 {% macro postgres__regexp_instr(source_value, regexp, position, occurrence) %}
 array_length((select regexp_matches({{ source_value }}, '{{ regexp }}')), 1)


### PR DESCRIPTION
with the change to adapter resolution in dbt 0.20, redshift has been
using the postgres version of the macro, which fails because the
function `regexp_matches` exists on Postgres but not Redshift. While the
`regexp_instr` does exist on Redshift, so the default was correct all
along.

This commit simply adds an explicit adapter for Redshift that is the
same as the default adapter.

This should fix #97 