### PR TITLE
[Feature] Add row_condition on expect_grouped_row_values_to_have_recent_data test

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,14 +187,14 @@ models: # or seeds:
             timestamp_column: date_day
             datepart: day
             interval: 1
-            row_condition: 'id is not null' #optional
+            row_condition: "id is not null" #optional
         # or also:
         - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
             group_by: [group_id, other_group_id]
             timestamp_column: date_day
             datepart: day
             interval: 1
-            row_condition: 'id is not null' #optional
+            row_condition: "id is not null" #optional
 ```
 
 ### [expect_table_column_count_to_be_between](macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql)

--- a/README.md
+++ b/README.md
@@ -186,14 +186,14 @@ models: # or seeds:
             timestamp_column: date_day
             datepart: day
             interval: 1
-            row_condition: 'where id is not null' #optional
+            row_condition: 'id is not null' #optional
         # or also:
         - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
             group_by: [group_id, other_group_id]
             timestamp_column: date_day
             datepart: day
             interval: 1
-            row_condition: 'where id is not null' #optional
+            row_condition: 'id is not null' #optional
 ```
 
 ### [expect_table_column_count_to_be_between](macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ tests:
 ### [expect_grouped_row_values_to_have_recent_data](macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql)
 
 Expect the model to have **grouped** rows that are at least as recent as the defined interval prior to the current timestamp.
-Use this to test whether there is recent data for each grouped row defined by `group_by` (which is a list of columns) and a `timestamp_column`.
+Use this to test whether there is recent data for each grouped row defined by `group_by` (which is a list of columns) and a `timestamp_column`. Optionally gives the possibility to apply filters on the results.
 
 *Applies to:* Model, Seed, Source
 
@@ -186,12 +186,14 @@ models: # or seeds:
             timestamp_column: date_day
             datepart: day
             interval: 1
+            row_condition: 'where id is not null' #optional
         # or also:
         - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
             group_by: [group_id, other_group_id]
             timestamp_column: date_day
             datepart: day
             interval: 1
+            row_condition: 'where id is not null' #optional
 ```
 
 ### [expect_table_column_count_to_be_between](macros/schema_tests/table_shape/expect_table_column_count_to_be_between.sql)

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ tests:
 
 ### [expect_row_values_to_have_recent_data](macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql)
 
-Expect the model to have rows that are at least as recent as the defined interval prior to the current timestamp.
+Expect the model to have rows that are at least as recent as the defined interval prior to the current timestamp. Optionally gives the possibility to apply filters on the results.
 
 *Applies to:* Column
 
@@ -168,6 +168,7 @@ tests:
   - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
         interval: 1
+        row_condition: 'id is not null' #optional
 ```
 
 ### [expect_grouped_row_values_to_have_recent_data](macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql)

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -75,6 +75,10 @@ models:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: "{{ dbt_expectations.type_datetime() }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
@@ -317,4 +321,10 @@ models:
             timestamp_column: date_day
             datepart: day
             interval: 1
+        - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
+            group_by: [group_id]
+            timestamp_column: date_day
+            datepart: day
+            interval: 1
+            row_condition: group_id = 4
 

--- a/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -36,16 +36,21 @@ with latest_grouped_timestamps as (
 
     {{ dbt_utils.group_by(group_by | length )}}
 
-
 ),
 total_row_counts as (
-    select max(1) as join_key, count(*) as row_count from latest_grouped_timestamps
+
+    select
+        max(1) as join_key,
+        count(*) as row_count
+    from
+        latest_grouped_timestamps
+
 ),
 outdated_grouped_timestamps as (
 
     select *
     from
-        latest_grouped_timestamps t
+        latest_grouped_timestamps
     where
         latest_timestamp_column < {{ dbt_utils.dateadd(datepart, interval * -1, dbt_date.now()) }}
 
@@ -64,7 +69,8 @@ validation_errors as (
         -- fail if either no rows were returned due to row_condition,
         -- or the recency test returned failed rows
         r.row_count = 0
-        or t.join_key is not null
+        or
+        t.join_key is not null
 
 )
 select * from validation_errors

--- a/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -1,24 +1,35 @@
 {% test expect_grouped_row_values_to_have_recent_data(model,
-                                                            group_by,
-                                                            timestamp_column,
-                                                            datepart,
-                                                            interval,
-                                                            row_condition=None) %}
+                                                        group_by,
+                                                        timestamp_column,
+                                                        datepart,
+                                                        interval,
+                                                        row_condition=None) %}
 
- {{ adapter.dispatch('test_expect_grouped_row_values_to_have_recent_data', 'dbt_expectations') (model, group_by, timestamp_column, datepart, interval, row_condition) }}
+ {{ adapter.dispatch('test_expect_grouped_row_values_to_have_recent_data', 'dbt_expectations') (model,
+                                                                                                group_by,
+                                                                                                timestamp_column,
+                                                                                                datepart,
+                                                                                                interval,
+                                                                                                row_condition) }}
 
 {% endtest %}
 
-{% macro default__test_expect_grouped_row_values_to_have_recent_data(model, group_by, timestamp_column, datepart, interval, row_condition) %}
+{% macro default__test_expect_grouped_row_values_to_have_recent_data(model,
+                                                                        group_by,
+                                                                        timestamp_column,
+                                                                        datepart,
+                                                                        interval,
+                                                                        row_condition) %}
 with latest_grouped_timestamps as (
 
     select
         {%- for g in group_by %}
         {{ g }},
         {%- endfor %}
+        max(1) as join_key,
         max({{ timestamp_column }}) as latest_timestamp_column
-    from {{ model }}
-
+    from
+        {{ model }}
     {% if row_condition %}
     where {{ row_condition }}
     {% endif %}
@@ -27,13 +38,33 @@ with latest_grouped_timestamps as (
 
 
 ),
-validation_errors as (
+total_row_counts as (
+    select max(1) as join_key, count(*) as row_count from latest_grouped_timestamps
+),
+outdated_grouped_timestamps as (
 
     select *
     from
-        latest_grouped_timestamps
+        latest_grouped_timestamps t
     where
         latest_timestamp_column < {{ dbt_utils.dateadd(datepart, interval * -1, dbt_date.now()) }}
+
+),
+validation_errors as (
+
+    select
+        r.row_count,
+        t.*
+    from
+        total_row_counts r
+        left join
+        outdated_grouped_timestamps t
+        on r.join_key = t.join_key
+    where
+        -- fail if either no rows were returned due to row_condition,
+        -- or the recency test returned failed rows
+        r.row_count = 0
+        or t.join_key is not null
 
 )
 select * from validation_errors

--- a/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -1,10 +1,15 @@
-{% test expect_grouped_row_values_to_have_recent_data(model, group_by, timestamp_column, datepart, interval) %}
+{% test expect_grouped_row_values_to_have_recent_data(model,
+                                                            group_by,
+                                                            timestamp_column,
+                                                            datepart,
+                                                            interval,
+                                                            row_condition=None) %}
 
- {{ adapter.dispatch('test_expect_grouped_row_values_to_have_recent_data', 'dbt_expectations') (model, group_by, timestamp_column, datepart, interval) }}
+ {{ adapter.dispatch('test_expect_grouped_row_values_to_have_recent_data', 'dbt_expectations') (model, group_by, timestamp_column, datepart, interval, row_condition) }}
 
 {% endtest %}
 
-{% macro default__test_expect_grouped_row_values_to_have_recent_data(model, group_by, timestamp_column, datepart, interval) %}
+{% macro default__test_expect_grouped_row_values_to_have_recent_data(model, group_by, timestamp_column, datepart, interval, row_condition) %}
 with latest_grouped_timestamps as (
 
     select
@@ -12,9 +17,14 @@ with latest_grouped_timestamps as (
         {{ g }},
         {%- endfor %}
         max({{ timestamp_column }}) as latest_timestamp_column
-    from
-        {{ model }}
+    from {{ model }}
+
+    {% if row_condition %}
+    where {{ row_condition }}
+    {% endif %}
+
     {{ dbt_utils.group_by(group_by | length )}}
+
 
 ),
 validation_errors as (

--- a/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
@@ -1,4 +1,19 @@
-{% test expect_row_values_to_have_recent_data(model, column_name, datepart, interval) %}
+{% test expect_row_values_to_have_recent_data(model,
+                                                column_name,
+                                                datepart,
+                                                interval,
+                                                row_condition=None) %}
+
+ {{ adapter.dispatch('test_expect_row_values_to_have_recent_data', 'dbt_expectations') (model,
+                                                                                        column_name,
+                                                                                        datepart,
+                                                                                        interval,
+                                                                                        row_condition) }}
+
+{% endtest %}
+
+{% macro default__test_expect_row_values_to_have_recent_data(model, column_name, datepart, interval, row_condition) %}
+{%- set default_start_date = '1970-01-01' -%}
 with max_recency as (
 
     select max({{ column_name }} ) as max_date
@@ -6,12 +21,18 @@ with max_recency as (
         {{ model }}
     where
         {{ column_name }} <= {{ dbt_date.today() }}
+        {% if row_condition %}
+        and {{ row_condition }}
+        {% endif %}
 )
 select
     *
 from
     max_recency
 where
-    max_date < {{ dbt_utils.dateadd(datepart, interval * -1, dbt_date.now()) }}
+    -- if the row_condition excludes all row, we need to compare against a default date
+    -- to avoid false negatives
+    coalesce(max_date, '{{ default_start_date }}')
+        < {{ dbt_utils.dateadd(datepart, interval * -1, dbt_date.now()) }}
 
-{% endtest %}
+{% endmacro %}


### PR DESCRIPTION
This PR add the possibility to apply conditions (`row_condition`) to `expect_grouped_row_values_to_have_recent_data` test