### PR TITLE
Convert set logic to SQL joins

### DIFF
--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_values_to_equal_set.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_values_to_equal_set.sql
@@ -7,7 +7,7 @@
 with all_values as (
 
     select distinct
-        {{ column_name }} as value_field
+        {{ column_name }} as column_value
 
     from {{ model }}
     {% if row_condition %}
@@ -38,17 +38,18 @@ unique_set_values as (
 validation_errors as (
 
     select
-        count(v.value_field) as column_values,
-        count(s.value_field) as set_values
+        *
     from
         all_values v
         full outer join
-        unique_set_values s on v.value_field = s.value_field
+        unique_set_values s on v.column_value = s.value_field
+    where
+        v.column_value is null or
+        s.value_field is null
 
 )
 
 select *
 from validation_errors
-where column_values != set_values
 
 {% endtest %}

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
@@ -2,18 +2,52 @@
 {%- if execute -%}
     {%- set column_list = column_list | map(transform) | list -%}
     {%- set relation_column_names = dbt_expectations._get_column_list(model, transform) -%}
+    {%- set matching_columns = dbt_expectations._list_intersect(column_list, relation_column_names) -%}
+    with relation_columns as (
 
-    {%- set ordered_column_names = column_list | join(", ") -%}
-    {%- set ordered_relation_column_names = relation_column_names | join(", ") -%}
-    with test_data as (
-
+        {% for col_name in relation_column_names %}
         select
-            cast('{{ ordered_column_names }}' as {{ dbt_utils.type_string() }}) as ordered_column_names,
-            cast('{{ ordered_relation_column_names }}' as {{ dbt_utils.type_string() }}) as ordered_relation_column_names
+            '{{ col_name }}' as relation_column
+        {% if not loop.last %}union all{% endif %}
+        {% endfor %}
+    ),
+    input_columns as (
+
+        {% for col_name in column_list %}
+        select
+            '{{ col_name }}' as input_column
+
+        {% if not loop.last %}union all{% endif %}
+        {% endfor %}
+    ),
+    relation_columns_sequence as (
+        -- (BigQuery won't let you use a window function without a "from" clause)
+        select
+            relation_column,
+            row_number() over() as relation_column_idx
+        from
+            relation_columns
+
+    ),
+    input_columns_sequence as (
+        -- (BigQuery won't let you use a window function without a "from" clause)
+        select
+            input_column,
+            row_number() over() as input_column_idx
+        from
+            input_columns
 
     )
     select *
-    from test_data
-    where ordered_column_names != ordered_relation_column_names
+    from
+        relation_columns_sequence r
+        full outer join
+        input_columns_sequence i on r.relation_column = i.input_column and r.relation_column_idx = i.input_column_idx
+    where
+        -- catch any column in input list that is not in the sequence of table columns
+        -- or any table column that is not in the input sequence
+        r.relation_column is null or
+        i.input_column is null
+
 {%- endif -%}
 {%- endtest -%}

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
@@ -3,16 +3,30 @@
     {%- set column_list = column_list | map(transform) | list -%}
     {%- set relation_column_names = dbt_expectations._get_column_list(model, transform) -%}
     {%- set matching_columns = dbt_expectations._list_intersect(column_list, relation_column_names) -%}
-    with test_data as (
+    with relation_columns as (
 
-        select
-            {{ relation_column_names | length }} as number_columns,
-            {{ matching_columns | length }} as number_matching_columns
+        {% for col_name in relation_column_names %}
+        select '{{ col_name }}' as relation_column
+        {% if not loop.last %}union all{% endif %}
+        {% endfor %}
+    ),
+    input_columns as (
 
+        {% for col_name in column_list %}
+        select '{{ col_name }}' as input_column
+        {% if not loop.last %}union all{% endif %}
+        {% endfor %}
     )
     select *
-    from test_data
-    where number_columns != number_matching_columns
+    from
+        relation_columns r
+        full outer join
+        input_columns i on r.relation_column = i.input_column
+    where
+        -- catch any column in input list that is not in the list of table columns
+        -- or any table column that is not in the input list
+        r.relation_column is null or
+        i.input_column is null
 
 {%- endif -%}
 {%- endtest -%}


### PR DESCRIPTION
Converts set logic to SQL joins in the following tests:
- expect_column_distinct_values_to_equal_set
- expect_column_values_to_be_in_type_list
- expect_table_columns_to_contain_set
- expect_table_columns_to_match_ordered_list
- expect_table_columns_to_match_set

Closes #100 