### PR TITLE
Fix expect_row_values_to_have_data_for_every_n_datepart errors when both start and end dates are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,7 +914,12 @@ tests:
 
 Expects model to have values for every grouped `date_part`.
 
-For example, this tests whether a model has data for every `day` (grouped on `date_col`) from either a specified `start_date` and `end_date`, or for the `min`/`max` value of the specified `date_col`.
+For example, this tests whether a model has data for every `day` (grouped on `date_col`) from either:
+
+-   The `min`/`max` value of the specified `date_col` (default).
+-   A specified `test_start_date` and/or `test_end_date`.
+
+Note: `test_end_date` is exclusive (i.e. test will be passing on `test_end_date: '2020-01-05'` and your `date_col`'s `max` is equal to `'2021-01-04'`).
 
 *Applies to:* Model, Seed, Source
 

--- a/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
+++ b/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
@@ -21,11 +21,11 @@
 
     {% endset %}
 
-{% endif %}
+    {%- set dr = run_query(sql) -%}
+    {%- set db_start_date = dr.columns[0].values()[0].strftime('%Y-%m-%d') -%}
+    {%- set db_end_date = dr.columns[1].values()[0].strftime('%Y-%m-%d') -%}
 
-{%- set dr = run_query(sql) -%}
-{%- set db_start_date = dr.columns[0].values()[0].strftime('%Y-%m-%d') -%}
-{%- set db_end_date = dr.columns[1].values()[0].strftime('%Y-%m-%d') -%}
+{% endif %}
 
 {% if not test_start_date %}
 {% set start_date = db_start_date %}


### PR DESCRIPTION
Hey @clausherther, just implementing @barberscott's fix for #113 here.

----

Tested with the following:

<details>
  <summary>model / schema</summary>

```sql
-- dim_dates.sql
SELECT *
  FROM (VALUES ('2020-01-01'::DATE), ('2020-01-02'::DATE), ('2020-01-03'::DATE), ('2020-01-04'::DATE))
    AS my_table(date_at)
```

```yml
# dim_dates.yml
version: 2
models:
  - name: dim_dates
    columns:
      - name: date_at
        tests:
          - accepted_values:
              values: ["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"]
    tests:
      - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
          # Expect this to PASS.
          date_col: date_at
          date_part: day
          test_start_date: "2020-01-01"
          test_end_date: "2020-01-04"
      - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
          # Expect this to PASS.
          date_col: date_at
          date_part: day
          test_end_date: "2020-01-04"
      - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
          # Expect this to FAIL.
          date_col: date_at
          date_part: day
          test_start_date: "2019-12-01"
      - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
          # Expect this to FAIL.
          date_col: date_at
          date_part: day
          test_end_date: "2020-12-01"
      - dbt_expectations.expect_row_values_to_have_data_for_every_n_datepart:
          # Expect this to FAIL.
          date_col: date_at
          date_part: day
          test_start_date: "2020-01-01"
          test_end_date: "2020-01-06"
```

</details>


<details>
  <summary><code>dbt test -m dim_dates</code> output</summary>
  
```sh
Running with dbt=0.20.2
Found 4 models, 14 tests, 0 snapshots, 0 analyses, 540 macros, 0 operations, 0 seed files, 0 sources, 0 exposures

15:08:39 | Concurrency: 1 threads (target='dev')
15:08:39 | 
15:08:39 | 1 of 6 START test accepted_values_dim_dates_date_at__2020_01_01__2020_01_02__2020_01_03__2020_01_04 [RUN]
15:08:42 | 1 of 6 PASS accepted_values_dim_dates_date_at__2020_01_01__2020_01_02__2020_01_03__2020_01_04 [[32mPASS[0m in 3.26s]
15:08:42 | 2 of 6 START test dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2019_12_01 [RUN]
15:08:47 | 2 of 6 FAIL 31 dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2019_12_01 [[31mFAIL 31[0m in 4.69s]
15:08:47 | 3 of 6 START test dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_01_04 [RUN]
15:08:51 | 3 of 6 PASS dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_01_04 [[32mPASS[0m in 4.35s]
15:08:51 | 4 of 6 START test dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_01_04__2020_01_01 [RUN]
15:08:55 | 4 of 6 PASS dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_01_04__2020_01_01 [[32mPASS[0m in 3.89s]
15:08:55 | 5 of 6 START test dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_01_06__2020_01_01 [RUN]
15:08:59 | 5 of 6 FAIL 1 dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_01_06__2020_01_01 [[31mFAIL 1[0m in 3.82s]
15:08:59 | 6 of 6 START test dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_12_01 [RUN]
15:09:04 | 6 of 6 FAIL 331 dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_12_01 [[31mFAIL 331[0m in 4.60s]
15:09:04 | 
15:09:04 | Finished running 6 tests in 30.05s.

[31mCompleted with 3 errors and 0 warnings:[0m

[31mFailure in test dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2019_12_01 (models/testing_dbt_expectations/dim_dates.yml)[0m
  Got 31 results, configured to fail if != 0

  compiled SQL at target/compiled/snowflake/models/testing_dbt_expectations/dim_dates.yml/schema_test/dbt_expectations_expect_row_va_983cdf96730122e510782406c066c373.sql

[31mFailure in test dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_01_06__2020_01_01 (models/testing_dbt_expectations/dim_dates.yml)[0m
  Got 1 result, configured to fail if != 0

  compiled SQL at target/compiled/snowflake/models/testing_dbt_expectations/dim_dates.yml/schema_test/dbt_expectations_expect_row_va_bdb191a0149f9b0d3c08c5c8db6ab40d.sql

[31mFailure in test dbt_expectations_expect_row_values_to_have_data_for_every_n_datepart_dim_dates_date_at__day__2020_12_01 (models/testing_dbt_expectations/dim_dates.yml)[0m
  Got 331 results, configured to fail if != 0

  compiled SQL at target/compiled/snowflake/models/testing_dbt_expectations/dim_dates.yml/schema_test/dbt_expectations_expect_row_va_4cd32499e35de4d43a0427496f6139d9.sql

Done. PASS=3 WARN=0 ERROR=3 SKIP=0 TOTAL=6
```
</details>