### PR TITLE
Replace hardcoded transform in expect_column_to_exist

### DIFF
--- a/macros/schema_tests/table_shape/expect_column_to_exist.sql
+++ b/macros/schema_tests/table_shape/expect_column_to_exist.sql
@@ -1,7 +1,7 @@
 {%- test expect_column_to_exist(model, column_name, column_index=None, transform="upper") -%}
 {%- if execute -%}
 
-    {%- set column_name = column_name | upper -%}
+    {%- set column_name = column_name | map(transform) | join -%}
     {%- set relation_column_names = dbt_expectations._get_column_list(model, transform) -%}
 
     {%- set matching_column_index = relation_column_names.index(column_name) if column_name in relation_column_names else -1 %}


### PR DESCRIPTION
Replaced hardcoded value with mapping call to provided transform filter and join to reduce list back to single value.