### PR TITLE
Fix Redshift compatibility

### DIFF
--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
@@ -8,7 +8,7 @@
         {% for col_name in relation_column_names %}
         select
             {{ loop.index }} as relation_column_idx,
-            '{{ col_name }}' as relation_column
+            cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
@@ -17,8 +17,7 @@
         {% for col_name in column_list %}
         select
             {{ loop.index }} as input_column_idx,
-            '{{ col_name }}' as input_column
-
+            cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )


### PR DESCRIPTION
The `expect_table_columns_to_match_ordered_list` macro is using column
names as direct strings, which doesn't work on Redshift without an
explicit cast to string.

This cast was added previously and removed again in
https://github.com/calogica/dbt-expectations/commit/c698a1a1108435c18cc7680885795aeb47b8fe74#diff-14b201719d47d2b58e18a4896f8cb1d1f0bc3b414694499ef5eb738b683fb955L11-L12

Fixes #122 

I have not tested this, just applied the previous fix.