### PR TITLE
Fix missing group_by default value in string_matching macros

### DIFF
--- a/macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql
+++ b/macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql
@@ -7,7 +7,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern.sql
@@ -7,7 +7,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_like_pattern_list.sql
@@ -15,7 +15,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_regex.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_regex.sql
@@ -9,7 +9,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_match_regex_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_match_regex_list.sql
@@ -15,7 +15,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern.sql
@@ -7,7 +7,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_like_pattern_list.sql
@@ -15,7 +15,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex.sql
@@ -9,7 +9,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}

--- a/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex_list.sql
+++ b/macros/schema_tests/string_matching/expect_column_values_to_not_match_regex_list.sql
@@ -15,7 +15,7 @@
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,
-                                        group_by_columns=group_by,
+                                        group_by_columns=None,
                                         row_condition=row_condition
                                         )
                                         }}


### PR DESCRIPTION
Fix for issue #125.

Problem: All the methods in macros/schema_tests/string_matching/ define a group_by_columns=group_by functionality, but group_by is not defined in the method which makes them fail with 'MacroGenerator' object is not iterable.

Solution: we set group_by = None as it's not used by the method.