### PR TITLE
Patch release to support dbt 0.1.x 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 target/
 dbt_modules/
+dbt_packages/
 logs/
 .python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
+# dbt-expectations v0.4.7
+* Patch: adds support for dbt 1.x
 
+# dbt-expectations v0.4.6
+
+## What's Changed
+* Append missing optional parameters documentation to README.md by @makotonium in https://github.com/calogica/dbt-expectations/pull/124
+* Fix missing group_by default value in string_matching macros by @samantha-guerriero-cko in https://github.com/calogica/dbt-expectations/pull/126
+
+## New Contributors
+* @makotonium made their first contribution in https://github.com/calogica/dbt-expectations/pull/124
+* @samantha-guerriero-cko made their first contribution in https://github.com/calogica/dbt-expectations/pull/126
 # dbt-expectations v0.4.5
 
 ## Fixes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,11 +5,11 @@
 name: 'dbt_expectations'
 version: '0.4.0'
 
-require-dbt-version: [">=0.20.0", "<0.22.0"]
+require-dbt-version: [">=0.20.0", "<1.1.0"]
 config-version: 2
 
 target-path: "target"
-clean-targets: ["target", "dbt_modules"]
+clean-targets: ["target", "dbt_modules", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -13,9 +13,7 @@ data-paths: ["data"]
 macro-paths: ["macros"]
 
 target-path: "target"
-clean-targets:
-    - "target"
-    - "dbt_modules"
+clean-targets: ["target", "dbt_modules", "dbt_packages"]
 
 dispatch:
   - macro_namespace: dbt_expectations

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -79,9 +79,6 @@ models:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1
-          - dbt_expectations.expect_row_values_to_have_recent_data:
-              datepart: day
-              interval: 1
 
           - dbt_expectations.expect_column_values_to_be_of_type:
               column_type: "{{ dbt_expectations.type_datetime() }}"


### PR DESCRIPTION
This is a backwards compatible patch release that updates following files to support dbt 0.1.x

- .gitignore
- dbt_project.yml
- integration_tests/dbt_project.yml

This release will work with versions of versions of dbt-date < 0.5.0 (and in turn versions of dbt-utils < 0.8.0).

cc: @joellabes