### PR TITLE
Make string field types more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# dbt-expectations v0.5.1
+
+## Fixes
+* Add better support for Redshift by typing implicit `varchar` fields explicitly to strings. ([#131](https://github.com/calogica/dbt-expectations/pull/131) [#132](https://github.com/calogica/dbt-expectations/pull/132))
+
+
+# dbt-expectations v0.5.0
+* adds full support for dbt 1.x without backwards compatability
+* supports `dbt-date 0.5.0`, which supports `dbt-utils 0.8.0`
+
 # dbt-expectations v0.4.7
 * Patch: adds support for dbt 1.x
 

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_set.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_set.sql
@@ -20,7 +20,7 @@ set_values as (
     {% for value in value_set -%}
     select
         {% if quote_values -%}
-        '{{ value }}'
+        cast('{{ value }}' as {{ dbt_utils.type_string() }})
         {%- else -%}
         {{ value }}
         {%- endif %} as value_field

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_not_be_in_set.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_not_be_in_set.sql
@@ -20,7 +20,7 @@ set_values as (
     {% for value in value_set -%}
     select
         {% if quote_values -%}
-        '{{ value }}'
+        cast('{{ value }}' as {{ dbt_utils.type_string() }})
         {%- else -%}
         {{ value }}
         {%- endif %} as value_field

--- a/macros/schema_tests/multi-column/expect_column_pair_values_to_be_in_set.sql
+++ b/macros/schema_tests/multi-column/expect_column_pair_values_to_be_in_set.sql
@@ -12,7 +12,7 @@
 {% else %}
 {{ exceptions.raise_compiler_error(
         "`value_pairs_set` argument for expect_column_pair_values_to_be_in_set test cannot have more than 2 item per element.
-        Got: '" ~ pair ~"'.'"
+        Got: '" ~ pair ~ "'.'"
     ) }}
 {% endif %}
 {% endfor %}

--- a/macros/schema_tests/table_shape/expect_column_to_exist.sql
+++ b/macros/schema_tests/table_shape/expect_column_to_exist.sql
@@ -21,7 +21,7 @@
     with test_data as (
 
         select
-            '{{ column_name }}' as column_name,
+            cast('{{ column_name }}' as {{ dbt_utils.type_string() }}) as column_name,
             {{ matching_column_index }} as matching_column_index,
             {{ column_index_matches }} as column_index_matches
 

--- a/macros/schema_tests/table_shape/expect_table_columns_to_contain_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_contain_set.sql
@@ -6,14 +6,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select '{{ col_name }}' as relation_column
+        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select '{{ col_name }}' as input_column
+        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
@@ -6,14 +6,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select '{{ col_name }}' as relation_column
+        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select '{{ col_name }}' as input_column
+        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )


### PR DESCRIPTION
This adds better support for Redshift by typing implicit `varchar` fields explicitly to strings.
