### PR TITLE
Fix documentation to note DBT 1.0.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Install
 
-`dbt-expectations` currently supports `dbt 0.21.x`.
+`dbt-expectations` currently supports `dbt 1.0.x`.
 
 Check [dbt Hub](https://hub.getdbt.com/calogica/dbt_expectations/latest/) for the latest installation instructions, or [read the docs](https://docs.getdbt.com/docs/package-management) for more information on installing packages.
 


### PR DESCRIPTION
The README.md notes that the project only supports dbt 0.21.x, but dot-expectations 0.5.0 and above support 1.0.0.  

Just wanted to quickly change the documentation to minimize confusion.