### PR TITLE
Add test unique set case sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ To run the tests:
 - [expect_column_values_to_be_between](#expect_column_values_to_be_between)
 - [expect_column_values_to_be_decreasing](#expect_column_values_to_be_decreasing)
 - [expect_column_values_to_be_increasing](#expect_column_values_to_be_increasing)
-- [expect_column_distinct values to remain unique case insensitive](#expect_column_distinct values to remain unique case insensitive)
-
 ### String matching
 
 - [expect_column_value_lengths_to_be_between](#expect_column_value_lengths_to_be_between)
@@ -499,20 +497,6 @@ tests:
       max_value: 4 # (Optional)
       row_condition: "id is not null" # (Optional)
       strictly: false # (Optional. Default is 'false'. Adds an 'or equal to' to the comparison operator for min/max)
-```
-
-### [expect_column_distinct values to remain unique case insensitive](macros/schema_tests/column_values_basic/expect_column_set_to_be_unique_case_insensitive.sql)
-
-Expect column set of values to remain unique from a case insensitive perspective. 
-
-If the column contains the values "iPhone" and "iphone" then it would not match the expectation, as both values would be part of column's set of values but from a case insenstive perspective will be equal. 
-
-*Applies to:* Column
-
-```yaml
-tests:
-  - dbt_expectations.expect_column_set_to_be_unique_case_insensitive:
-
 ```
 
 ### [expect_column_value_lengths_to_equal](macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql)

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ To run the tests:
 - [expect_column_values_to_be_decreasing](#expect_column_values_to_be_decreasing)
 - [expect_column_values_to_be_increasing](#expect_column_values_to_be_increasing)
 ### String matching
-
 - [expect_column_value_lengths_to_be_between](#expect_column_value_lengths_to_be_between)
 - [expect_column_value_lengths_to_equal](#expect_column_value_lengths_to_equal)
 - [expect_column_values_to_match_like_pattern](#expect_column_values_to_match_like_pattern)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ To run the tests:
 - [expect_column_values_to_be_between](#expect_column_values_to_be_between)
 - [expect_column_values_to_be_decreasing](#expect_column_values_to_be_decreasing)
 - [expect_column_values_to_be_increasing](#expect_column_values_to_be_increasing)
+
 ### String matching
+
 - [expect_column_value_lengths_to_be_between](#expect_column_value_lengths_to_be_between)
 - [expect_column_value_lengths_to_equal](#expect_column_value_lengths_to_equal)
 - [expect_column_values_to_match_like_pattern](#expect_column_values_to_match_like_pattern)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ To run the tests:
 - [expect_column_values_to_be_between](#expect_column_values_to_be_between)
 - [expect_column_values_to_be_decreasing](#expect_column_values_to_be_decreasing)
 - [expect_column_values_to_be_increasing](#expect_column_values_to_be_increasing)
+- [expect_column_distinct values to remain unique case insensitive](#expect_column_distinct values to remain unique case insensitive)
 
 ### String matching
 
@@ -498,6 +499,20 @@ tests:
       max_value: 4 # (Optional)
       row_condition: "id is not null" # (Optional)
       strictly: false # (Optional. Default is 'false'. Adds an 'or equal to' to the comparison operator for min/max)
+```
+
+### [expect_column_distinct values to remain unique case insensitive](macros/schema_tests/column_values_basic/expect_column_set_to_be_unique_case_insensitive.sql)
+
+Expect column set of values to remain unique from a case insensitive perspective. 
+
+If the column contains the values "iPhone" and "iphone" then it would not match the expectation, as both values would be part of column's set of values but from a case insenstive perspective will be equal. 
+
+*Applies to:* Column
+
+```yaml
+tests:
+  - dbt_expectations.expect_column_set_to_be_unique_case_insensitive:
+
 ```
 
 ### [expect_column_value_lengths_to_equal](macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql)

--- a/macros/schema_tests/column_values_basic/expect_column_set_to_be_unique_case_insensitive
+++ b/macros/schema_tests/column_values_basic/expect_column_set_to_be_unique_case_insensitive
@@ -1,0 +1,24 @@
+{% test expect_column_set_to_be_unique_case_insensitive(model, column_name) %}
+
+ {%- if execute -%}
+ with test_data as (
+
+     select
+         distinct {{ column_name }} as distinct_values
+         FROM
+         {{ model }}
+         where 1=1
+
+ ),
+ validation_errors as
+ (
+   select
+   count(1) as set_count,
+   count(distinct lower(distinct_values)) as set_count_case_insensitive
+   from test_data
+ )
+ select * from validation_errors
+ where set_count!=set_count_case_insensitive
+
+ {%- endif -%}
+ {%- endtest -%}


### PR DESCRIPTION
Compares if the unique values of a given column remain unique from a case insensitive perspective. Useful when dealing with CamelCase and lowercase uniqueness within a column. Example: the test would fail if "MasterCard" and "mastercard" are in the same column.

I don't know the guidelines of the commits, but I can take care of adding the corresponding links and description to the README. 