### PR TITLE
Change check for data date out of range to use timestamp

### DIFF
--- a/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
@@ -20,7 +20,7 @@ with max_recency as (
     from
         {{ model }}
     where
-        {{ column_name }} <= {{ dbt_date.today() }}
+        {{ column_name }} <= {{ dbt_date.now() }}
         {% if row_condition %}
         and {{ row_condition }}
         {% endif %}


### PR DESCRIPTION
This PR addresses #104 by using timestamps as the comparison to work out older data.

This was driven by experiencing an issue using the test on data using a timestamp as the recency source for data that should be fresher than 6 hours.

The original code was pulling data from the table that had a timestamp <= todays date, meaning that although the most recent data was loaded 15 minutes before, the test was failing.

Tested on Snowflake

Apologies if this doesn't meet the standards for contributions for the repo, but before #139 is implemented, it's justa guess :(

Also please let me know if anything else is required