### PR TITLE
Added partition by in lag tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ tests:
       sort_column: date_day
       row_condition: "id is not null" # (Optional)
       strictly: true # (Optional for comparison operator. Default is 'true', and it uses '>'. If set to 'false' it uses '>='.)
-      partition_columns: partition_col_1, partition_col_2 # (Optional: default is None)
+      group_by: [group_id, other_group_id, ...] # (Optional)
 ```
 
 ### [expect_column_values_to_be_decreasing](macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql)
@@ -497,7 +497,7 @@ tests:
       sort_column: col_numeric_a
       row_condition: "id is not null" # (Optional)
       strictly: true # (Optional for comparison operator. Default is 'true' and it uses '<'. If set to 'false', it uses '<='.)
-      partition_columns: partition_col_1, partition_col_2 # (Optional: default is None)
+      group_by: [group_id, other_group_id, ...] # (Optional)
 ```
 
 ### [expect_column_value_lengths_to_be_between](macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql)

--- a/README.md
+++ b/README.md
@@ -479,14 +479,15 @@ tests:
   - dbt_expectations.expect_column_values_to_be_increasing:
       sort_column: date_day
       row_condition: "id is not null" # (Optional)
-      strictly: true # (Optional for comparison operator. Default is 'true', and it uses '>'. If set to 'flase' it uses '>='.)
+      strictly: true # (Optional for comparison operator. Default is 'true', and it uses '>'. If set to 'false' it uses '>='.)
+      partition_columns: partition_col_1, partition_col_2 # (Optional: default is None)
 ```
 
 ### [expect_column_values_to_be_decreasing](macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql)
 
 Expect column values to be decreasing.
 
-If strictly=True, then this expectation is only satisfied if each consecutive value is strictly increasing–equal values are treated as failures.
+If `strictly=True`, then this expectation is only satisfied if each consecutive value is strictly increasing–equal values are treated as failures.
 
 *Applies to:* Column
 
@@ -494,8 +495,9 @@ If strictly=True, then this expectation is only satisfied if each consecutive va
 tests:
   - dbt_expectations.expect_column_values_to_be_decreasing:
       sort_column: col_numeric_a
-      strictly: true # (Optional for comparison operator. Default is 'true' and it uses '<'. If set to 'false', it uses '<='.)
       row_condition: "id is not null" # (Optional)
+      strictly: true # (Optional for comparison operator. Default is 'true' and it uses '<'. If set to 'false', it uses '<='.)
+      partition_columns: partition_col_1, partition_col_2 # (Optional: default is None)
 ```
 
 ### [expect_column_value_lengths_to_be_between](macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql)

--- a/integration_tests/models/schema_tests/data_test.sql
+++ b/integration_tests/models/schema_tests/data_test.sql
@@ -32,10 +32,10 @@ select
 union all
 
 select
-  4 as idx,
-  '2020-10-23' as date_col,
-  0.5 as col_numeric_a,
-  0.5 as col_numeric_b,
-  'c' as col_string_a,
-  'abcd' as col_string_b,
-  null as col_null
+    4 as idx,
+    '2020-10-23' as date_col,
+    0.5 as col_numeric_a,
+    0.5 as col_numeric_b,
+    'c' as col_string_a,
+    'abcd' as col_string_b,
+    null as col_null

--- a/integration_tests/models/schema_tests/emails.sql
+++ b/integration_tests/models/schema_tests/emails.sql
@@ -1,3 +1,20 @@
+{% if execute %}
+{%- set source_relation = adapter.get_relation(
+      database="bigquery-public-data",
+      schema="new_york_citibike",
+      identifier="citibike_trips") -%}
+
+{{ log("Source Relation: " ~ source_relation, info=true) }}
+{% endif %}
+
+{% if execute %}
+{%- set source_relation_2 = adapter.get_relation(
+      database=this.database,
+      schema=this.schema,
+      identifier=this.name) -%}
+
+{{ log("Source Relation: " ~ source_relation_2, info=true) }}
+{% endif %}
 select
     'ab@gmail.com' as email_address,
     '@[^.]*' as reg_exp

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -333,16 +333,16 @@ models:
 
   - name: window_function_test
     columns:
-      - name: rolling_sum_numeric_a
+      - name: rolling_sum_increasing
         tests :
           - dbt_expectations.expect_column_values_to_be_increasing:
-                group_by: ['idx']
-                strictly: false
-                sort_column: date_col
+              group_by: ['idx']
+              strictly: true
+              sort_column: date_col
 
-      - name: rolling_sum_numeric_b
+      - name: rolling_sum_decreasing
         tests :
-          - dbt_expectations.expect_column_values_to_be_desscreasing:
-                group_by: ['idx']
-                strictly: false
-                sort_column: date_col
+          - dbt_expectations.expect_column_values_to_be_decreasing:
+              group_by: ['idx']
+              strictly: true
+              sort_column: date_col

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -330,3 +330,14 @@ models:
             datepart: day
             interval: 1
             row_condition: group_id = 4
+
+  - name: window_function_test
+    tests :
+        - dbt_expectations.expect_column_values_to_be_increasing:
+            group_by: ['rolling_sum_numeric_a']
+            strictly: false
+            sort_column: date_col
+        - dbt_expectations.expect_column_values_to_be_decreasing:
+            group_by: ['rolling_sum_numeric_b']
+            strictly: false
+            sort_column: date_col 

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -332,12 +332,17 @@ models:
             row_condition: group_id = 4
 
   - name: window_function_test
-    tests :
-        - dbt_expectations.expect_column_values_to_be_increasing:
-            group_by: ['rolling_sum_numeric_a']
-            strictly: false
-            sort_column: date_col
-        - dbt_expectations.expect_column_values_to_be_decreasing:
-            group_by: ['rolling_sum_numeric_b']
-            strictly: false
-            sort_column: date_col 
+    columns:
+      - name: rolling_sum_numeric_a
+        tests :
+          - dbt_expectations.expect_column_values_to_be_increasing:
+                group_by: ['idx']
+                strictly: false
+                sort_column: date_col
+
+      - name: rolling_sum_numeric_b
+        tests :
+          - dbt_expectations.expect_column_values_to_be_desscreasing:
+                group_by: ['idx']
+                strictly: false
+                sort_column: date_col

--- a/integration_tests/models/schema_tests/window_function_test.sql
+++ b/integration_tests/models/schema_tests/window_function_test.sql
@@ -1,30 +1,48 @@
 with data_example as (
-select * from {{ ref('data_test') }}
+
+    select
+        1 as idx,
+        '2020-10-21' as date_col,
+        cast(0 as {{ dbt_utils.type_float() }}) as col_numeric_a
 
     union all
 
-select
-    2 as idx,
-    '2020-10-23' as date_col,
-    2 as col_numeric_a,
-    -1 as col_numeric_b,
-    'b' as col_string_a,
-    'ab' as col_string_b,
-    null as col_null
+    select
+        2 as idx,
+        '2020-10-22' as date_col,
+        1 as col_numeric_a
 
     union all
 
-select
-    2 as idx,
-    '2020-10-24' as date_col,
-    1 as col_numeric_a,
-    -1 as col_numeric_b,
-    'b' as col_string_a,
-    'ab' as col_string_b,
-    null as col_null
+    select
+        2 as idx,
+        '2020-10-23' as date_col,
+        2 as col_numeric_a
+
+    union all
+
+    select
+        2 as idx,
+        '2020-10-24' as date_col,
+        1 as col_numeric_a
+
+    union all
+
+    select
+        3 as idx,
+        '2020-10-23' as date_col,
+        0.5 as col_numeric_a
+    union all
+
+    select
+        4 as idx,
+        '2020-10-23' as date_col,
+        0.5 as col_numeric_a
+
 )
-
-select *
-        , SUM(col_numeric_a) over (partition by idx order by date_col) as rolling_sum_numeric_a
-        , SUM(col_numeric_b) over (partition by idx order by date_col) as rolling_sum_numeric_b
-from data_example
+select
+    *,
+    sum(col_numeric_a) over (partition by idx order by date_col) as rolling_sum_increasing,
+    sum(col_numeric_a) over (partition by idx order by date_col desc) as rolling_sum_decreasing
+from
+    data_example

--- a/integration_tests/models/schema_tests/window_function_test.sql
+++ b/integration_tests/models/schema_tests/window_function_test.sql
@@ -1,0 +1,30 @@
+with data_example as (
+select * from {{ ref('data_test') }}
+
+    union all
+
+select
+    2 as idx,
+    '2020-10-23' as date_col,
+    2 as col_numeric_a,
+    -1 as col_numeric_b,
+    'b' as col_string_a,
+    'ab' as col_string_b,
+    null as col_null
+
+    union all
+
+select
+    2 as idx,
+    '2020-10-24' as date_col,
+    1 as col_numeric_a,
+    -1 as col_numeric_b,
+    'b' as col_string_a,
+    'ab' as col_string_b,
+    null as col_null
+)
+
+select *
+        , SUM(col_numeric_a) over (partition by idx order by date_col) as rolling_sum_numeric_a
+        , SUM(col_numeric_b) over (partition by idx order by date_col) as rolling_sum_numeric_b
+from data_example

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
@@ -2,44 +2,37 @@
                                                    sort_column=None,
                                                    strictly=True,
                                                    row_condition=None,
-                                                   partition_columns=None) %}
-
+                                                   group_by=None) %}
 {%- set sort_column = column_name if not sort_column else sort_column -%}
 {%- set operator = "<" if strictly else "<=" %}
-{%- set partition_columns_list = partition_columns.split(',') %}
 with all_values as (
-
     select
         {{ sort_column }} as sort_column,
         {{ column_name }} as value_field
-        {%- if partition_columns -%}
-            {%- for columns in partition_columns_list -%}
+        {%- if group_by -%}
+            {%- for columns in group_by -%}
         , {{ columns }}
-            {%- endfor -%}
+            {% endfor %}
         {%- endif %}
     from {{ model }}
     {% if row_condition %}
     where {{ row_condition }}
     {% endif %}
-
 ),
 add_lag_values as (
-
     select
         sort_column,
         value_field,
         lag(value_field) over
-            {%- if not partition_columns -%}
+            {%- if not group_by -%}
                 (order by sort_column)
             {%- else -%}
-                (partition by {{ partition_columns }} order by sort_column)
-            {%- endif -%}    as value_field_lag    
+                (partition by {{ group_by|join(", ") }} order by sort_column)
+            {%- endif  %}    as value_field_lag
     from
         all_values
-
 ),
 validation_errors as (
-
     select
         *
     from
@@ -48,7 +41,6 @@ validation_errors as (
         value_field_lag is not null
         and
         not (value_field {{ operator }} value_field_lag)
-
 )
 select *
 from validation_errors

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
@@ -1,16 +1,22 @@
 {% test expect_column_values_to_be_decreasing(model, column_name,
                                                    sort_column=None,
                                                    strictly=True,
-                                                   row_condition=None) %}
+                                                   row_condition=None,
+                                                   partition_columns=None) %}
 
 {%- set sort_column = column_name if not sort_column else sort_column -%}
 {%- set operator = "<" if strictly else "<=" %}
+{%- set partition_columns_list = partition_columns.split(',') %}
 with all_values as (
 
     select
         {{ sort_column }} as sort_column,
         {{ column_name }} as value_field
-
+        {%- if partition_columns -%}
+            {%- for columns in partition_columns_list -%}
+        , {{ columns }}
+            {%- endfor -%}
+        {%- endif %}
     from {{ model }}
     {% if row_condition %}
     where {{ row_condition }}
@@ -22,7 +28,12 @@ add_lag_values as (
     select
         sort_column,
         value_field,
-        lag(value_field) over(order by sort_column) as value_field_lag
+        lag(value_field) over
+            {%- if not partition_columns -%}
+                (order by sort_column)
+            {%- else -%}
+                (partition by {{ partition_columns }} order by sort_column)
+            {%- endif -%}    as value_field_lag    
     from
         all_values
 

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql
@@ -3,23 +3,25 @@
                                                    strictly=True,
                                                    row_condition=None,
                                                    group_by=None) %}
+
 {%- set sort_column = column_name if not sort_column else sort_column -%}
 {%- set operator = "<" if strictly else "<=" %}
 with all_values as (
+
     select
         {{ sort_column }} as sort_column,
-        {{ column_name }} as value_field
         {%- if group_by -%}
-            {%- for columns in group_by -%}
-        , {{ columns }}
-            {% endfor %}
+        {{ group_by | join(", ") }},
         {%- endif %}
+        {{ column_name }} as value_field
     from {{ model }}
     {% if row_condition %}
     where {{ row_condition }}
     {% endif %}
+
 ),
 add_lag_values as (
+
     select
         sort_column,
         value_field,
@@ -27,12 +29,14 @@ add_lag_values as (
             {%- if not group_by -%}
                 (order by sort_column)
             {%- else -%}
-                (partition by {{ group_by|join(", ") }} order by sort_column)
-            {%- endif  %}    as value_field_lag
+                (partition by {{ group_by | join(", ") }} order by sort_column)
+            {%- endif  %} as value_field_lag
     from
         all_values
+
 ),
 validation_errors as (
+
     select
         *
     from
@@ -41,6 +45,7 @@ validation_errors as (
         value_field_lag is not null
         and
         not (value_field {{ operator }} value_field_lag)
+
 )
 select *
 from validation_errors

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
@@ -1,34 +1,40 @@
 {% test expect_column_values_to_be_increasing(model, column_name,
                                                    sort_column=None,
                                                    strictly=True,
-                                                   row_condition=None) %}
+                                                   row_condition=None,
+                                                   partition_columns=None) %}
 
 {%- set sort_column = column_name if not sort_column else sort_column -%}
 {%- set operator = ">" if strictly else ">=" %}
+{%- set partition_columns_list = partition_columns.split(',') %}
 with all_values as (
-
     select
         {{ sort_column }} as sort_column,
         {{ column_name }} as value_field
-
+        {%- if partition_columns -%}
+            {%- for columns in partition_columns_list -%}
+        , {{ columns }}
+            {%- endfor -%}
+        {%- endif %}
     from {{ model }}
     {% if row_condition %}
     where {{ row_condition }}
     {% endif %}
-
 ),
 add_lag_values as (
-
     select
         sort_column,
         value_field,
-        lag(value_field) over(order by sort_column) as value_field_lag
+        lag(value_field) over
+            {%- if not partition_columns -%}
+                (order by sort_column)
+            {%- else -%}
+                (partition by {{ partition_columns }} order by sort_column)
+            {%- endif -%}    as value_field_lag
     from
         all_values
-
 ),
 validation_errors as (
-
     select
         *
     from
@@ -37,7 +43,6 @@ validation_errors as (
         value_field_lag is not null
         and
         not (value_field {{ operator }} value_field_lag)
-
 )
 select *
 from validation_errors

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
@@ -2,17 +2,16 @@
                                                    sort_column=None,
                                                    strictly=True,
                                                    row_condition=None,
-                                                   partition_columns=None) %}
+                                                   group_by=None) %}
 
 {%- set sort_column = column_name if not sort_column else sort_column -%}
 {%- set operator = ">" if strictly else ">=" %}
-{%- set partition_columns_list = partition_columns.split(',') %}
 with all_values as (
     select
         {{ sort_column }} as sort_column,
         {{ column_name }} as value_field
-        {%- if partition_columns -%}
-            {%- for columns in partition_columns_list -%}
+        {%- if group_by -%}
+            {%- for columns in group_by_list -%}
         , {{ columns }}
             {%- endfor -%}
         {%- endif %}
@@ -26,11 +25,11 @@ add_lag_values as (
         sort_column,
         value_field,
         lag(value_field) over
-            {%- if not partition_columns -%}
+            {%- if not group_by -%}
                 (order by sort_column)
             {%- else -%}
-                (partition by {{ partition_columns }} order by sort_column)
-            {%- endif -%}    as value_field_lag
+                (partition by {{ group_by|join(", ") }} order by sort_column)
+            {%- endif  %}    as value_field_lag
     from
         all_values
 ),


### PR DESCRIPTION
# Problem: 
Not possible to put partition by parameters in the following tests:
- [expect_column_values_to_be_increasing](https://github.com/calogica/dbt-expectations/blob/main/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql)
- [expect_column_values_to_be_decreasing](https://github.com/calogica/dbt-expectations/blob/main/macros/schema_tests/column_values_basic/expect_column_values_to_be_decreasing.sql)

# Changes:
- Added an optional parameter which allow to partition by. 
- Updated the README.MD with accordingly

Please let me know if there is anything