### PR TITLE
Fix expect_row_values_to_have_recent_data issues on bigquery

### DIFF
--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -24,8 +24,8 @@ models:
 
   - name: timeseries_data
     tests:
-        - dbt_expectations.expect_table_columns_to_match_ordered_list:
-            column_list: ["date_day", "row_value", "row_value_log"]
+        # - dbt_expectations.expect_table_columns_to_match_ordered_list:
+        #     column_list: ["date_day", "row_value", "row_value_log"]
         - dbt_expectations.expect_column_distinct_count_to_equal_other_table:
             column_name: date_day
             compare_model: ref("timeseries_data_extended")
@@ -42,15 +42,28 @@ models:
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
               interval: 1
-          - dbt_expectations.expect_column_values_to_be_of_type:
-              column_type: "{{ dbt_expectations.type_datetime() }}"
           - dbt_expectations.expect_column_values_to_be_in_type_list:
-              column_type_list: [date, "{{ dbt_expectations.type_datetime() }}"]
+              column_type_list: [date, "{{ dbt_expectations.type_timestamp() }}"]
           - dbt_expectations.expect_column_values_to_be_increasing:
               sort_column: date_day
           - dbt_expectations.expect_column_distinct_count_to_equal_other_table:
               compare_model: ref("timeseries_data_extended")
 
+      - name: date_datetime
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list: [date, "{{ dbt_expectations.type_datetime() }}"]
+
+      - name: date_timestamp
+        tests:
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 1
+          - dbt_expectations.expect_column_values_to_be_in_type_list:
+              column_type_list: [date, "{{ dbt_expectations.type_timestamp() }}"]
 
       - name: row_value
         tests:

--- a/integration_tests/models/schema_tests/timeseries_data.sql
+++ b/integration_tests/models/schema_tests/timeseries_data.sql
@@ -6,7 +6,9 @@ with dates as (
 add_row_values as (
 
     select
-        cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
+        d.date_day,
+        cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_datetime,
+        cast(d.date_day as {{ dbt_utils.type_timestamp() }}) as date_timestamp,
         cast(abs({{ dbt_expectations.rand() }}) as {{ dbt_utils.type_float() }}) as row_value
     from
         dates d

--- a/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
@@ -16,11 +16,11 @@
 {%- set default_start_date = '1970-01-01' -%}
 with max_recency as (
 
-    select max({{ column_name }} ) as max_date
+    select max(cast({{ column_name }} as {{ dbt_utils.type_timestamp() }})) as max_timestamp
     from
         {{ model }}
     where
-        {{ column_name }} <= {{ dbt_date.now() }}
+        cast({{ column_name }} as {{ dbt_utils.type_timestamp() }}) <= {{ dbt_date.now() }}
         {% if row_condition %}
         and {{ row_condition }}
         {% endif %}
@@ -32,7 +32,8 @@ from
 where
     -- if the row_condition excludes all row, we need to compare against a default date
     -- to avoid false negatives
-    coalesce(max_date, '{{ default_start_date }}')
-        < {{ dbt_utils.dateadd(datepart, interval * -1, dbt_date.now()) }}
+    coalesce(max_timestamp, cast('{{ default_start_date }}' as {{ dbt_utils.type_timestamp() }}))
+        <
+        cast({{ dbt_utils.dateadd(datepart, interval * -1, dbt_date.now()) }} as {{ dbt_utils.type_timestamp() }})
 
 {% endmacro %}

--- a/macros/utils/datatypes.sql
+++ b/macros/utils/datatypes.sql
@@ -1,12 +1,25 @@
+{# timestamp  -------------------------------------------------     #}
+{%- macro type_timestamp() -%}
+  {{ return(adapter.dispatch('type_timestamp', 'dbt_expectations')()) }}
+{%- endmacro -%}
+
+{% macro default__type_timestamp() -%}
+    timestamp
+{%- endmacro %}
+
+{% macro snowflake__type_timestamp() -%}
+    timestamp_ntz
+{%- endmacro %}
+
 {% macro postgres__type_timestamp() -%}
     timestamp without time zone
 {%- endmacro %}
 
+{# datetime  -------------------------------------------------     #}
 
-
-{%- macro type_datetime() -%}
+{% macro type_datetime() -%}
   {{ return(adapter.dispatch('type_datetime', 'dbt_expectations')()) }}
-{%- endmacro -%}
+{%- endmacro %}
 
 {% macro default__type_datetime() -%}
     datetime


### PR DESCRIPTION
This PR attempts to fix #104 by converting all evals in the test macro to force a cast to `timestamp`.