### PR TITLE
fix: quote column_name before passing to dbt_utils.length in expect_column_value_lengths_to_be_between

### DIFF
--- a/integration_tests/models/schema_tests/data_test.sql
+++ b/integration_tests/models/schema_tests/data_test.sql
@@ -5,7 +5,8 @@ select
     cast(1 as {{ dbt_utils.type_float() }}) as col_numeric_b,
     'a' as col_string_a,
     'b' as col_string_b,
-    cast(null as {{ dbt_utils.type_string() }}) as col_null
+    cast(null as {{ dbt_utils.type_string() }}) as col_null,
+    'a reserved keyword' as "offset"
 
 union all
 
@@ -16,7 +17,8 @@ select
     0 as col_numeric_b,
     'b' as col_string_a,
     'ab' as col_string_b,
-    null as col_null
+    null as col_null,
+    'a reserved keyword' as "offset"
 
 union all
 
@@ -27,7 +29,8 @@ select
     0.5 as col_numeric_b,
     'c' as col_string_a,
     'abc' as col_string_b,
-    null as col_null
+    null as col_null,
+    'a reserved keyword' as "offset"
 
 union all
 
@@ -38,4 +41,5 @@ select
     0.5 as col_numeric_b,
     'c' as col_string_a,
     'abcd' as col_string_b,
-    null as col_null
+    null as col_null,
+    'a reserved keyword' as "offset"

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -150,7 +150,7 @@ models:
             row_condition: 1=1
             compare_row_condition: 1=1
         - dbt_expectations.expect_table_column_count_to_equal:
-            value: 7
+            value: 8
         - dbt_expectations.expect_table_column_count_to_be_between:
             min_value: 1
             max_value: 10
@@ -298,6 +298,7 @@ models:
           - dbt_expectations.expect_column_values_to_be_null
 
       - name: offset
+        quote: true
         tests:
           - dbt_expectations.expect_column_value_lengths_to_be_between:
               min_value: 1

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -161,9 +161,9 @@ models:
         - dbt_expectations.expect_table_columns_to_contain_set:
             column_list: ["col_numeric_b", "col_string_a"]
         - dbt_expectations.expect_table_columns_to_match_set:
-            column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null"]
+            column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null", "offset"]
         - dbt_expectations.expect_table_columns_to_match_ordered_list:
-            column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null"]
+            column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null", "offset"]
         - dbt_expectations.expect_table_column_count_to_equal_other_table:
             compare_model: ref("data_test")
         - dbt_expectations.expression_is_true:
@@ -296,6 +296,16 @@ models:
       - name: col_null
         tests:
           - dbt_expectations.expect_column_values_to_be_null
+
+      - name: offset
+        tests:
+          - dbt_expectations.expect_column_value_lengths_to_be_between:
+              min_value: 1
+              max_value: 20
+          - dbt_expectations.expect_column_value_lengths_to_be_between:
+              min_value: 1
+          - dbt_expectations.expect_column_value_lengths_to_be_between:
+              max_value: 20
 
   - name : data_test_factored
     tests :

--- a/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
+++ b/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
@@ -5,7 +5,7 @@
                                                          strictly=False
                                                       ) %}
 {% set expression %}
-{{ dbt_utils.length(column_name) }}
+{{ dbt_utils.length('"' + column_name + '"') }}
 {% endset %}
 
 {{ dbt_expectations.expression_between(model,

--- a/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
+++ b/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
@@ -5,7 +5,7 @@
                                                          strictly=False
                                                       ) %}
 {% set expression %}
-{{ dbt_utils.length('"' + column_name + '"') }}
+{{ dbt_utils.length(column_name) }}
 {% endset %}
 
 {{ dbt_expectations.expression_between(model,


### PR DESCRIPTION
Fixes #150

If the column name is a reserved keyword, `expect_column_value_lengths_to_be_between` tests would fail because the column name should be quoted before being passed to `dbt_utils.length`. This PR adds quotes around `column_name` in this generic test.