### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+- repo: local
+  hooks:
+  - id: dbt_build_postgres
+    name: dbt_build_postgres
+    entry: "dbt build --project-dir integration_tests -t postgres"
+    language: system
+    pass_filenames: false
+  - id: dbt_build_bigquery
+    stages: [push]
+    name: dbt_build_bigquery
+    entry: "dbt build --project-dir integration_tests -t bq"
+    language: system
+    pass_filenames: false
+  - id: dbt_build_snowflake
+    stages: [push]
+    name: dbt_build_snowflake
+    entry: "dbt build --project-dir integration_tests -t snowflake"
+    language: system
+    pass_filenames: false


### PR DESCRIPTION
This PR adds pre-commit and pre-push hooks to run dbt build on the integration_tests project.
It'll, locally, run `dbt build` for `postgres` on each commit, and run `dbt build` on a defined `bq` (BigQuery) and `snowflake` target on push.