### PR TITLE
Show group_by columns in validation errors for column increasing test

### DIFF
--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_increasing.sql
@@ -24,6 +24,9 @@ add_lag_values as (
 
     select
         sort_column,
+        {%- if group_by -%}
+        {{ group_by | join(", ") }},
+        {%- endif %}
         value_field,
         lag(value_field) over
             {%- if not group_by -%}


### PR DESCRIPTION
# Description

Quick suggestion - if there are multiple `group_by` keys it's a lot easier to look for test failures if we include them in the select and then they show up in validation errors.

There's probably a reason i'm not thinking of that this wasn't included initially - will close if that's the case