### PR TITLE
Add group_by option to expect_column_values_to_be_within_n_moving_stdevs

### DIFF
--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -378,6 +378,16 @@ models:
             datepart: day
             interval: 1
 
+    columns:
+      - name: row_value
+        tests:
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: date_day
+              group_by: [group_id]
+              sigma_threshold: 6
+              take_logs: true
+              severity: warn
+
   - name: window_function_test
     columns:
       - name: rolling_sum_increasing

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -12,6 +12,7 @@ coalesce({{ metric_column }}, 0)
 {% test expect_column_values_to_be_within_n_moving_stdevs(model,
                                   column_name,
                                   date_column_name,
+                                  group_by=None,
                                   period='day',
                                   lookback_periods=1,
                                   trend_periods=7,
@@ -25,6 +26,7 @@ coalesce({{ metric_column }}, 0)
     {{ adapter.dispatch('test_expect_column_values_to_be_within_n_moving_stdevs', 'dbt_expectations') (model,
                                   column_name,
                                   date_column_name,
+                                  group_by,
                                   period,
                                   lookback_periods,
                                   trend_periods,
@@ -40,6 +42,7 @@ coalesce({{ metric_column }}, 0)
 {% macro default__test_expect_column_values_to_be_within_n_moving_stdevs(model,
                                   column_name,
                                   date_column_name,
+                                  group_by,
                                   period,
                                   lookback_periods,
                                   trend_periods,
@@ -53,6 +56,8 @@ coalesce({{ metric_column }}, 0)
 
 {%- set sigma_threshold_upper = sigma_threshold_upper if sigma_threshold_upper else sigma_threshold -%}
 {%- set sigma_threshold_lower = sigma_threshold_lower if sigma_threshold_lower else -1 * sigma_threshold -%}
+{%- set partition_by = "partition by " ~ (group_by | join(",")) if group_by -%}
+{%- set group_by_length = (group_by | length ) if group_by else 0 -%}
 
 with metric_values as (
 
@@ -60,11 +65,11 @@ with metric_values as (
 
         select
             {{ dbt_utils.date_trunc(period, date_column_name) }} as metric_period,
+            {{ group_by | join(",") ~ "," if group_by }}
             sum({{ column_name }}) as agg_metric_value
         from
             {{ model }}
-        group by
-            1
+        {{  dbt_utils.group_by(1 + group_by_length) }}
 
     )
     {%- if take_diffs %}
@@ -72,7 +77,9 @@ with metric_values as (
 
         select
             *,
-            lag(agg_metric_value, {{ lookback_periods }}) over(order by metric_period) as prior_agg_metric_value
+            lag(agg_metric_value, {{ lookback_periods }}) over(
+                {{ partition_by }}
+                order by metric_period) as prior_agg_metric_value
     from
         grouped_metric_values d
 
@@ -103,10 +110,12 @@ metric_moving_calcs as (
     select
         *,
         avg(metric_test_value)
-            over(order by metric_period rows
+            over({{ partition_by }}
+                    order by metric_period rows
                     between {{ trend_periods }} preceding and 1 preceding) as metric_test_rolling_average,
         stddev(metric_test_value)
-            over(order by metric_period rows
+            over({{ partition_by }}
+                    order by metric_period rows
                     between {{ trend_periods }} preceding and 1 preceding) as metric_test_rolling_stddev
     from
         metric_values


### PR DESCRIPTION
Closes #166 
This PR adds an option to specify a grouping level for the `expect_column_values_to_be_within_n_moving_stdevs` test. This allows uses to check for anomalies over time within groups, such as products or customers.

if `group_by` is specified, the macro groups the initial metric aggregation and then adds `partition_by` statements to the relevant window functions.

E.g.
```yaml
  - name : my_model
    columns:
      - name: row_value
        tests:
          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
              date_column_name: date_day
              group_by: [group_id]
              sigma_threshold: 3
              take_logs: true
              severity: warn
```
