### PR TITLE
Migrate to dbt-utils 0.9.0 and dbt-date 0.6.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,9 +3,9 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'dbt_expectations'
-version: '0.5.0'
+version: '0.6.0'
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.2.0", "<2.0.0"]
 config-version: 2
 
 target-path: "target"

--- a/integration_tests/models/schema_tests/data_test.sql
+++ b/integration_tests/models/schema_tests/data_test.sql
@@ -1,11 +1,11 @@
 select
     1 as idx,
     '2020-10-21' as date_col,
-    cast(0 as {{ dbt_utils.type_float() }}) as col_numeric_a,
-    cast(1 as {{ dbt_utils.type_float() }}) as col_numeric_b,
+    cast(0 as {{ type_float() }}) as col_numeric_a,
+    cast(1 as {{ type_float() }}) as col_numeric_b,
     'a' as col_string_a,
     'b' as col_string_b,
-    cast(null as {{ dbt_utils.type_string() }}) as col_null
+    cast(null as {{ type_string() }}) as col_null
 
 union all
 

--- a/integration_tests/models/schema_tests/timeseries_data.sql
+++ b/integration_tests/models/schema_tests/timeseries_data.sql
@@ -8,8 +8,8 @@ add_row_values as (
     select
         d.date_day,
         cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_datetime,
-        cast(d.date_day as {{ dbt_utils.type_timestamp() }}) as date_timestamp,
-        cast(abs({{ dbt_expectations.rand() }}) as {{ dbt_utils.type_float() }}) as row_value
+        cast(d.date_day as {{ type_timestamp() }}) as date_timestamp,
+        cast(abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
     from
         dates d
 

--- a/integration_tests/models/schema_tests/timeseries_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_extended.sql
@@ -10,7 +10,7 @@ add_row_values as (
 
     select
         cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
-        cast(abs({{ dbt_expectations.rand() }}) as {{ dbt_utils.type_float() }}) as row_value
+        cast(abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
     from
         dates d
         cross join

--- a/integration_tests/models/schema_tests/timeseries_data_grouped.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_grouped.sql
@@ -12,8 +12,8 @@ add_row_values as (
     select
         cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
         cast(d.date_day as {{ dbt_expectations.type_timestamp() }}) as date_timestamp,
-        cast(g.generated_number as {{ dbt_utils.type_int() }}) as group_id,
-        cast(floor(100 * r.generated_number) as {{ dbt_utils.type_int() }}) as row_value
+        cast(g.generated_number as {{ type_int() }}) as group_id,
+        cast(floor(100 * r.generated_number) as {{ type_int() }}) as row_value
     from
         dates d
         cross join

--- a/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
@@ -10,7 +10,7 @@ add_row_values as (
 
     select
         cast(d.date_hour as {{ dbt_expectations.type_datetime() }}) as date_hour,
-        cast(abs({{ dbt_expectations.rand() }}) as {{ dbt_utils.type_float() }}) as row_value
+        cast(abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
     from
         dates d
         cross join

--- a/integration_tests/models/schema_tests/window_function_test.sql
+++ b/integration_tests/models/schema_tests/window_function_test.sql
@@ -3,7 +3,7 @@ with data_example as (
     select
         1 as idx,
         '2020-10-21' as date_col,
-        cast(0 as {{ dbt_utils.type_float() }}) as col_numeric_a
+        cast(0 as {{ type_float() }}) as col_numeric_a
 
     union all
 

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_set.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_set.sql
@@ -20,7 +20,7 @@ set_values as (
     {% for value in value_set -%}
     select
         {% if quote_values -%}
-        cast('{{ value }}' as {{ dbt_utils.type_string() }})
+        cast('{{ value }}' as {{ type_string() }})
         {%- else -%}
         {{ value }}
         {%- endif %} as value_field

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -8,8 +8,8 @@
 
         {% for column in columns_in_relation %}
         select
-            cast('{{ column.name | upper }}' as {{ dbt_utils.type_string() }}) as relation_column,
-            cast('{{ column.dtype | upper }}' as {{ dbt_utils.type_string() }}) as relation_column_type
+            cast('{{ column.name | upper }}' as {{ type_string() }}) as relation_column,
+            cast('{{ column.dtype | upper }}' as {{ type_string() }}) as relation_column_type
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_not_be_in_set.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_not_be_in_set.sql
@@ -20,7 +20,7 @@ set_values as (
     {% for value in value_set -%}
     select
         {% if quote_values -%}
-        cast('{{ value }}' as {{ dbt_utils.type_string() }})
+        cast('{{ value }}' as {{ type_string() }})
         {%- else -%}
         {{ value }}
         {%- endif %} as value_field

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -59,7 +59,7 @@ with metric_values as (
     with grouped_metric_values as (
 
         select
-            {{ dbt_utils.date_trunc(period, date_column_name) }} as metric_period,
+            {{ date_trunc(period, date_column_name) }} as metric_period,
             sum({{ column_name }}) as agg_metric_value
         from
             {{ model }}
@@ -129,10 +129,10 @@ from
 where
 
     metric_period >= cast(
-            {{ dbt_utils.dateadd(period, -test_periods, dbt_utils.date_trunc(period, dbt_date.now())) }}
-            as {{ dbt_utils.type_timestamp() }})
+            {{ dateadd(period, -test_periods, date_trunc(period, dbt_date.now())) }}
+            as {{ type_timestamp() }})
     and
-    metric_period < {{ dbt_utils.date_trunc(period, dbt_date.now()) }}
+    metric_period < {{ date_trunc(period, dbt_date.now()) }}
     and
 
     not (

--- a/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
+++ b/macros/schema_tests/string_matching/expect_column_value_lengths_to_be_between.sql
@@ -5,7 +5,7 @@
                                                          strictly=False
                                                       ) %}
 {% set expression %}
-{{ dbt_utils.length(column_name) }}
+{{ length(column_name) }}
 {% endset %}
 
 {{ dbt_expectations.expression_between(model,

--- a/macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql
+++ b/macros/schema_tests/string_matching/expect_column_value_lengths_to_equal.sql
@@ -3,7 +3,7 @@
                                                     row_condition=None
                                                     ) %}
 
-{% set expression = dbt_utils.length(column_name) ~ " = " ~ value %}
+{% set expression = length(column_name) ~ " = " ~ value %}
 
 {{ dbt_expectations.expression_is_true(model,
                                         expression=expression,

--- a/macros/schema_tests/table_shape/expect_column_to_exist.sql
+++ b/macros/schema_tests/table_shape/expect_column_to_exist.sql
@@ -21,7 +21,7 @@
     with test_data as (
 
         select
-            cast('{{ column_name }}' as {{ dbt_utils.type_string() }}) as column_name,
+            cast('{{ column_name }}' as {{ type_string() }}) as column_name,
             {{ matching_column_index }} as matching_column_index,
             {{ column_index_matches }} as column_index_matches
 

--- a/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -27,12 +27,12 @@ with latest_grouped_timestamps as (
         {{ g }},
         {%- endfor %}
         max(1) as join_key,
-        max(cast({{ timestamp_column }} as {{ dbt_utils.type_timestamp() }})) as latest_timestamp_column
+        max(cast({{ timestamp_column }} as {{ type_timestamp() }})) as latest_timestamp_column
     from
         {{ model }}
     where
         -- to exclude erroneous future dates
-        cast({{ timestamp_column }} as {{ dbt_utils.type_timestamp() }}) <= {{ dbt_date.now() }}
+        cast({{ timestamp_column }} as {{ type_timestamp() }}) <= {{ dbt_date.now() }}
         {% if row_condition %}
         and {{ row_condition }}
         {% endif %}
@@ -58,8 +58,8 @@ outdated_grouped_timestamps as (
         -- are the max timestamps per group older than the specified cutoff?
         latest_timestamp_column <
             cast(
-                {{ dbt_utils.dateadd(datepart, interval * -1, dbt_date.now()) }}
-                as {{ dbt_utils.type_timestamp() }}
+                {{ dateadd(datepart, interval * -1, dbt_date.now()) }}
+                as {{ type_timestamp() }}
             )
 
 ),

--- a/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
@@ -16,12 +16,12 @@
 {%- set default_start_date = '1970-01-01' -%}
 with max_recency as (
 
-    select max(cast({{ column_name }} as {{ dbt_utils.type_timestamp() }})) as max_timestamp
+    select max(cast({{ column_name }} as {{ type_timestamp() }})) as max_timestamp
     from
         {{ model }}
     where
         -- to exclude erroneous future dates
-        cast({{ column_name }} as {{ dbt_utils.type_timestamp() }}) <= {{ dbt_date.now() }}
+        cast({{ column_name }} as {{ type_timestamp() }}) <= {{ dbt_date.now() }}
         {% if row_condition %}
         and {{ row_condition }}
         {% endif %}
@@ -33,8 +33,8 @@ from
 where
     -- if the row_condition excludes all rows, we need to compare against a default date
     -- to avoid false negatives
-    coalesce(max_timestamp, cast('{{ default_start_date }}' as {{ dbt_utils.type_timestamp() }}))
+    coalesce(max_timestamp, cast('{{ default_start_date }}' as {{ type_timestamp() }}))
         <
-        cast({{ dbt_utils.dateadd(datepart, interval * -1, dbt_date.now()) }} as {{ dbt_utils.type_timestamp() }})
+        cast({{ dateadd(datepart, interval * -1, dbt_date.now()) }} as {{ type_timestamp() }})
 
 {% endmacro %}

--- a/macros/schema_tests/table_shape/expect_table_columns_to_contain_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_contain_set.sql
@@ -6,14 +6,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
+        select cast('{{ col_name }}' as {{ type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
+        select cast('{{ col_name }}' as {{ type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
@@ -8,7 +8,7 @@
         {% for col_name in relation_column_names %}
         select
             {{ loop.index }} as relation_column_idx,
-            cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
+            cast('{{ col_name }}' as {{ type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
@@ -17,7 +17,7 @@
         {% for col_name in column_list %}
         select
             {{ loop.index }} as input_column_idx,
-            cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
+            cast('{{ col_name }}' as {{ type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
@@ -6,14 +6,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
+        select cast('{{ col_name }}' as {{ type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
+        select cast('{{ col_name }}' as {{ type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/macros/schema_tests/table_shape/expect_table_columns_to_not_contain_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_not_contain_set.sql
@@ -6,14 +6,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as relation_column
+        select cast('{{ col_name }}' as {{ type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select cast('{{ col_name }}' as {{ dbt_utils.type_string() }}) as input_column
+        select cast('{{ col_name }}' as {{ type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: calogica/dbt_date
-    version: [">=0.5.0", "<0.6.0"]
+    version: [">=0.6.0", "<0.7.0"]


### PR DESCRIPTION
Closes #188 

- Removes references to macros now supported in dbt-core.
- Requires dbt-utils 0.9.x
- Requires dbt 1.2.x
