### PR TITLE
Add expect_column_distinct_count_to_be_less_than.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ For example, use `America/New_York` for East Coast Time.
 ### Aggregate functions
 
 - [expect_column_distinct_count_to_be_greater_than](#expect_column_distinct_count_to_be_greater_than)
+- [expect_column_distinct_count_to_be_less_than](#expect_column_distinct_count_to_be_less_than)
 - [expect_column_distinct_count_to_equal_other_table](#expect_column_distinct_count_to_equal_other_table)
 - [expect_column_distinct_count_to_equal](#expect_column_distinct_count_to_equal)
 - [expect_column_distinct_values_to_be_in_set](#expect_column_distinct_values_to_be_in_set)
@@ -680,6 +681,21 @@ Expect the number of distinct column values to be greater than a given value.
 ```yaml
 tests:
   - dbt_expectations.expect_column_distinct_count_to_be_greater_than:
+      value: 10
+      quote_values: false # (Optional. Default is 'false'.)
+      group_by: [group_id, other_group_id, ...] # (Optional)
+      row_condition: "id is not null" # (Optional)
+```
+
+### [expect_column_distinct_count_to_be_less_than](macros/schema_tests/aggregate_functions/expect_column_less_count_to_be_less_than.sql)
+
+Expect the number of distinct column values to be less than a given value.
+
+*Applies to:* Column
+
+```yaml
+tests:
+  - dbt_expectations.expect_column_distinct_count_to_be_less_than:
       value: 10
       quote_values: false # (Optional. Default is 'false'.)
       group_by: [group_id, other_group_id, ...] # (Optional)

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -321,6 +321,8 @@ models:
           - dbt_expectations.expect_column_values_to_have_consistent_casing
           - dbt_expectations.expect_column_values_to_have_consistent_casing:
               display_inconsistent_columns: true
+          - dbt_expectations.expect_column_distinct_count_to_be_less_than:
+              value: 4
 
       - name: col_string_b
         tests:

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -123,6 +123,10 @@ models:
           - dbt_expectations.expect_column_distinct_count_to_be_greater_than:
               row_condition: date_day = {{ dbt_date.yesterday() }}
               value: 1
+          - dbt_expectations.expect_column_distinct_count_to_be_less_than:
+              value: 11
+              row_condition: date_day = {{ dbt_date.yesterday() }}
+
 
 
       - name: row_value_log

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_less_than.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_less_than.sql
@@ -1,0 +1,16 @@
+{% test expect_column_distinct_count_to_be_less_than(model,
+                                                                column_name,
+                                                                value,
+                                                                quote_values=False,
+                                                                group_by=None,
+                                                                row_condition=None
+                                                                ) %}
+{% set expression %}
+count(distinct {{ column_name }}) < {{ value }}
+{% endset %}
+{{ dbt_expectations.expression_is_true(model,
+                                        expression=expression,
+                                        group_by_columns=group_by,
+                                        row_condition=row_condition)
+                                        }}
+{%- endtest -%}


### PR DESCRIPTION
- expect_column_distinct_count_to_be_less_than.sql is a copy of expect_column_distinct_count_to_be_greater_than.sql, but with "<" instead of ">"
- README.md is updated to reflect addition
