### PR TITLE
Fix boolean logic in `expect_compound_columns_to_be_unique` `ignore_row_if` 

### DIFF
--- a/integration_tests/models/schema_tests/data_test.sql
+++ b/integration_tests/models/schema_tests/data_test.sql
@@ -5,7 +5,8 @@ select
     cast(1 as {{ type_float() }}) as col_numeric_b,
     'a' as col_string_a,
     'b' as col_string_b,
-    cast(null as {{ type_string() }}) as col_null
+    cast(null as {{ type_string() }}) as col_null,
+    cast(null as {{ type_string() }}) as col_null_2
 
 union all
 
@@ -16,7 +17,8 @@ select
     0 as col_numeric_b,
     'b' as col_string_a,
     'ab' as col_string_b,
-    null as col_null
+    null as col_null,
+    null as col_null_2
 
 union all
 
@@ -27,7 +29,8 @@ select
     0.5 as col_numeric_b,
     'c' as col_string_a,
     'abc' as col_string_b,
-    null as col_null
+    null as col_null,
+    null as col_null_2
 
 union all
 
@@ -38,4 +41,5 @@ select
     0.5 as col_numeric_b,
     'c' as col_string_a,
     'abcd' as col_string_b,
-    null as col_null
+    null as col_null,
+    null as col_null_2

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -207,9 +207,9 @@ models:
             ignore_row_if: "all_values_are_missing"
             config:
                 # this should fail, so we flip the fail condition
-                fail_calc: '(count(*)=0)::int'
+                fail_calc: 'cast((count(*)=0) as int)'
         - dbt_expectations.expect_compound_columns_to_be_unique:
-            column_list: ["col_null", "col_null"]
+            column_list: ["col_null", "col_null_2"]
             ignore_row_if: "all_values_are_missing"
         - dbt_expectations.expect_table_row_count_to_equal:
             value: 4
@@ -225,7 +225,7 @@ models:
             row_condition: 1=1
             compare_row_condition: 1=1
         - dbt_expectations.expect_table_column_count_to_equal:
-            value: 7
+            value: 8
         - dbt_expectations.expect_table_column_count_to_be_between:
             min_value: 1
             max_value: 10
@@ -236,9 +236,9 @@ models:
         - dbt_expectations.expect_table_columns_to_contain_set:
             column_list: ["col_numeric_b", "col_string_a"]
         - dbt_expectations.expect_table_columns_to_match_set:
-            column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null"]
+            column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null", "col_null_2"]
         - dbt_expectations.expect_table_columns_to_match_ordered_list:
-            column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null"]
+            column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null", "col_null_2"]
         - dbt_expectations.expect_table_column_count_to_equal_other_table:
             compare_model: ref("data_test")
         - dbt_expectations.expect_table_columns_to_not_contain_set:

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -203,6 +203,12 @@ models:
             column_list: ["date_col", "col_null"]
             ignore_row_if: "any_value_is_missing"
         - dbt_expectations.expect_compound_columns_to_be_unique:
+            column_list: ["date_col", "col_null"]
+            ignore_row_if: "all_values_are_missing"
+            config:
+                # this should fail, so we flip the fail condition
+                fail_calc: '(count(*)=0)::int'
+        - dbt_expectations.expect_compound_columns_to_be_unique:
             column_list: ["col_null", "col_null"]
             ignore_row_if: "all_values_are_missing"
         - dbt_expectations.expect_table_row_count_to_equal:

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -199,6 +199,12 @@ models:
         - dbt_expectations.expect_compound_columns_to_be_unique:
             column_list: ["date_col", "col_string_b"]
             ignore_row_if: "all_values_are_missing"
+        - dbt_expectations.expect_compound_columns_to_be_unique:
+            column_list: ["date_col", "col_null"]
+            ignore_row_if: "any_value_is_missing"
+        - dbt_expectations.expect_compound_columns_to_be_unique:
+            column_list: ["col_null", "col_null"]
+            ignore_row_if: "all_values_are_missing"
         - dbt_expectations.expect_table_row_count_to_equal:
             value: 4
         - dbt_expectations.expect_table_row_count_to_be_between:

--- a/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
+++ b/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
@@ -9,6 +9,13 @@
         "`column_list` must be specified as a list of columns. Got: '" ~ column_list ~"'.'"
     ) }}
 {% endif %}
+{%- set ignore_row_if_values = ["all_values_are_missing", "any_value_is_missing"] -%}
+{% if ignore_row_if not in ignore_row_if_values %}
+    {{ exceptions.raise_compiler_error(
+        "`ignore_row_if` must be one of " ~ (ignore_row_if_values | join(", ")) ~ ". Got: '" ~ ignore_row_if ~"'.'"
+    ) }}
+{% endif %}
+
 {% if not quote_columns %}
     {%- set columns=column_list %}
 {% elif quote_columns %}

--- a/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
+++ b/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
@@ -28,19 +28,12 @@
     {{ row_condition }} and
 {% endif -%}
 
-{%- if ignore_row_if == "all_values_are_missing" %}
-        (
-            {% for column in columns -%}
-            {{ column }} is not null{% if not loop.last %} and {% endif %}
-            {% endfor %}
-        )
-{%- elif ignore_row_if == "any_value_is_missing" %}
-        (
-            {% for column in columns -%}
-            {{ column }} is not null{% if not loop.last %} or {% endif %}
-            {% endfor %}
-        )
-{%- endif -%}
+{%- set op = "and" if ignore_row_if == "all_values_are_missing" else "or" -%}
+    not (
+        {% for column in columns -%}
+        {{ column }} is null{% if not loop.last %} {{ op }} {% endif %}
+        {% endfor %}
+    )
 {%- endset -%}
 
 with validation_errors as (


### PR DESCRIPTION
Fixes #200 

This fixes the implementation of the `ignore_row_if` parameter in `expect_compound_columns_to_be_unique` highlighted by @mcannamela in #200 and adds a test to `data_test`. 