### PR TITLE
Fix group by logic in grouped recency and stdev tests

### DIFF
--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -98,6 +98,9 @@ models:
         tests:
           - dbt_expectations.expect_column_values_to_be_within_n_stdevs:
               sigma_threshold: 6
+          - dbt_expectations.expect_column_values_to_be_within_n_stdevs:
+              group_by: ["date_day"]
+              sigma_threshold: 6
           - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
               date_column_name: date_day
               sigma_threshold: 6
@@ -399,18 +402,12 @@ models:
             datepart: day
             interval: 1
         - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
-            group_by: [group_id, row_value]
-            timestamp_column: date_day
-            datepart: day
-            interval: 1
-        - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
             group_by: [group_id]
             timestamp_column: date_day
             datepart: day
             interval: 1
             row_condition: group_id = 4
         - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
-            group_by: [group_id]
             timestamp_column: date_timestamp
             datepart: day
             interval: 1
@@ -424,6 +421,10 @@ models:
               sigma_threshold: 6
               take_logs: true
               severity: warn
+          - dbt_expectations.expect_column_values_to_be_within_n_stdevs:
+              group_by: [group_id]
+              sigma_threshold: 6
+
 
   - name: window_function_test
     columns:

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -398,12 +398,12 @@ models:
             strictly: True
         - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
             group_by: [group_id]
-            timestamp_column: date_day
+            timestamp_column: date_timestamp
             datepart: day
             interval: 1
         - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
             group_by: [group_id]
-            timestamp_column: date_day
+            timestamp_column: date_timestamp
             datepart: day
             interval: 1
             row_condition: group_id = 4
@@ -411,6 +411,14 @@ models:
             timestamp_column: date_timestamp
             datepart: day
             interval: 1
+        - dbt_expectations.expect_grouped_row_values_to_have_recent_data:
+            group_by: [date_day]
+            timestamp_column: date_timestamp
+            datepart: day
+            interval: 1
+            config:
+                # this should fail, so we flip the fail condition
+                fail_calc: 'cast((count(*)=0) as int)'
 
     columns:
       - name: row_value
@@ -424,6 +432,14 @@ models:
           - dbt_expectations.expect_column_values_to_be_within_n_stdevs:
               group_by: [group_id]
               sigma_threshold: 6
+          - dbt_expectations.expect_column_values_to_be_within_n_stdevs:
+              sigma_threshold: 6
+          - dbt_expectations.expect_column_values_to_be_within_n_stdevs:
+              group_by: [group_id]
+              sigma_threshold: 1
+              config:
+                  # this should fail, so we flip the fail condition
+                  fail_calc: 'cast((count(*)=0) as int)'
 
 
   - name: window_function_test

--- a/integration_tests/models/schema_tests/timeseries_data.sql
+++ b/integration_tests/models/schema_tests/timeseries_data.sql
@@ -9,7 +9,8 @@ add_row_values as (
         date_day,
         cast(date_day as {{ dbt_expectations.type_datetime() }}) as date_datetime,
         cast(date_day as {{ type_timestamp() }}) as date_timestamp,
-        cast(abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+
     from
         dates
 

--- a/integration_tests/models/schema_tests/timeseries_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_extended.sql
@@ -8,7 +8,8 @@ add_row_values as (
 
     select
         cast(dates.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
-        cast(abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+
     from
         dates
         cross join row_values

--- a/integration_tests/models/schema_tests/timeseries_data_grouped.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_grouped.sql
@@ -13,7 +13,7 @@ add_row_values as (
         cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
         cast(d.date_day as {{ dbt_expectations.type_timestamp() }}) as date_timestamp,
         cast(g.generated_number as {{ type_int() }}) as group_id,
-        cast(floor(100 * r.generated_number) as {{ type_int() }}) as row_value
+        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
     from
         dates d
         cross join groupings g

--- a/integration_tests/models/schema_tests/timeseries_data_grouped.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_grouped.sql
@@ -10,14 +10,14 @@ row_values as (
 add_row_values as (
 
     select
-        cast(d.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
-        cast(d.date_day as {{ dbt_expectations.type_timestamp() }}) as date_timestamp,
-        cast(g.generated_number as {{ type_int() }}) as group_id,
+        cast(dates.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
+        cast(dates.date_day as {{ dbt_expectations.type_timestamp() }}) as date_timestamp,
+        cast(groupings.generated_number as {{ type_int() }}) as group_id,
         cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
     from
-        dates d
-        cross join groupings g
-        cross join row_values r
+        dates
+        cross join groupings
+        cross join row_values
 
 ),
 add_logs as (

--- a/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
@@ -10,7 +10,8 @@ add_row_values as (
 
     select
         cast(dates.date_hour as {{ dbt_expectations.type_datetime() }}) as date_hour,
-        cast(abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+
     from
         dates
         cross join row_values

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -126,7 +126,8 @@ metric_sigma as (
     select
         *,
         (metric_test_value - metric_test_rolling_average) as metric_test_delta,
-        (metric_test_value - metric_test_rolling_average)/nullif(metric_test_rolling_stddev, 0) as metric_test_sigma
+        (metric_test_value - metric_test_rolling_average)/
+            nullif(metric_test_rolling_stddev, 0) as metric_test_sigma
     from
         metric_moving_calcs
 

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
@@ -43,7 +43,7 @@ metric_values_z_scores as (
     select
         *,
         ({{ column_name }} - {{ column_name }}_average)/
-            {{ column_name }}_stddev as {{ column_name }}_sigma
+            nullif({{ column_name }}_stddev, 0) as {{ column_name }}_sigma
     from
         metric_values_with_statistics
 

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_stdevs.sql
@@ -3,7 +3,11 @@
                                   group_by=None,
                                   sigma_threshold=3
                                 ) -%}
-    {{ adapter.dispatch('test_expect_column_values_to_be_within_n_stdevs', 'dbt_expectations') (model, column_name, group_by, sigma_threshold) }}
+    {{
+        adapter.dispatch('test_expect_column_values_to_be_within_n_stdevs', 'dbt_expectations') (
+            model, column_name, group_by, sigma_threshold
+        )
+    }}
 {%- endtest %}
 
 {% macro default__test_expect_column_values_to_be_within_n_stdevs(model,
@@ -11,21 +15,16 @@
                                   group_by,
                                   sigma_threshold
                                 ) %}
+
 with metric_values as (
 
-    {% if group_by -%}
     select
-        {{ group_by }} as metric_date,
+        {{ group_by | join(",") ~ "," if group_by }}
         sum({{ column_name }}) as {{ column_name }}
     from
         {{ model }}
-    group by
-        1
-    {%- else -%}
-    select
-        {{ column_name }} as {{ column_name }}
-    from
-        {{ model }}
+    {% if group_by -%}
+    {{  dbt_utils.group_by(group_by | length) }}
     {%- endif %}
 
 ),
@@ -43,7 +42,8 @@ metric_values_z_scores as (
 
     select
         *,
-        ({{ column_name }} - {{ column_name }}_average)/{{ column_name }}_stddev as {{ column_name }}_sigma
+        ({{ column_name }} - {{ column_name }}_average)/
+            {{ column_name }}_stddev as {{ column_name }}_sigma
     from
         metric_values_with_statistics
 


### PR DESCRIPTION
* `expect_grouped_row_values_to_have_recent_data` did not correctly apply grouping levels to grouped recency checks
  * Closes #206 
* `expect_column_values_to_be_within_n_stdevs` did not expect a list for the `group_by`, unlike other similar tests
  * Closes #194