### PR TITLE
Update regexp_instr.sql

### DIFF
--- a/macros/regex/regexp_instr.sql
+++ b/macros/regex/regexp_instr.sql
@@ -31,3 +31,7 @@ array_length((select regexp_matches({{ source_value }}, '{{ regexp }}')), 1)
 {% macro redshift__regexp_instr(source_value, regexp, position, occurrence, is_raw) %}
 regexp_instr({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }})
 {% endmacro %}
+
+{% macro spark__regexp_instr(source_value, regexp, position, occurrence, is_raw) %}
+regexp_instr({{ source_value }}, '{{ regexp }}')
+{% endmacro %}


### PR DESCRIPTION
# The Error
The Spark `regexp_instr` function only takes two arguments, whereas the default version of the macro in this package provides 4. As a result I receive the following error when running in Databricks.
```zsh
18:01:44  Completed with 1 error and 0 warnings:
--
  | 18:01:44
  | 18:01:44  Runtime Error in test dbt_expectations_expect_column_values_to_not_match_regex_list_stg_google_ads__ad_history_source_final_urls__any___ (models/stg_google_ads.yml)
  | 18:01:44    Invalid number of arguments for function regexp_instr. Expected: one of 2 and 3; Found: 4; line 22 pos 0
  | 18:01:44
  | 18:01:44  Done. PASS=25 WARN=0 ERROR=1 SKIP=0 TOTAL=26
```

# Source of the Error
When looking further into the behavior, I see the function and argument for the 11.2 (and greater) Databricks runtime [here](https://docs.databricks.com/sql/language-manual/functions/regexp_instr.html). You can see in the docs the only arguments it accepts are the `str` and the `regexp` arguments. These map 1:1 with the `source_value` and `regexp` arguments in the `regexp_instr` macro within this package.

# The Proposed Solution
I noticed in `v0.6.0` the spark dispatch was removed from the macro. However, when upgrading to the latest version of the package I notice the above error since the default does not work with the 4 arguments opposed to the 2 that Databricks accepts for this function.

As such, I am proposing adding the spark dispatch back into the macro to resolve this error. The modification is quite minor in the sense that I am only removing the `position` and `occurrence` pieces from the function call. When I made this change and ran locally, I saw the following result.
```yml
## My configured yml
      - name: source_final_urls
        description: The original list of final urls expressed as an array. Please be aware the test used on this field is intended to warn you if you have fields with multiple urls. If you do, the `final_url` field will filter down the urls within the array to just the first. Therefore, this package will only leverage one of possibly many urls within this field array.
        tests:
          - dbt_expectations.expect_column_values_to_not_match_regex_list:
              regex_list: ","
              match_on: any
              severity: warn
```
```zsh
18:28:40  Completed with 1 warning:
18:28:40  
18:28:40  Warning in test dbt_expectations_expect_column_values_to_not_match_regex_list_stg_google_ads__ad_history_source_final_urls__any___ (models/stg_google_ads.yml)
18:28:40    Got 1 result, configured to warn if != 0
18:28:40  
18:28:40    compiled Code at target/compiled/google_ads_source/models/stg_google_ads.yml/dbt_expectations_expect_column_f02cb56d69a9df1e600b3958899ceaa5.sql
18:28:40  
18:28:40  Done. PASS=25 WARN=1 ERROR=0 SKIP=0 TOTAL=26
```
I can see if compiled with the warning as expected!

# Additional Details
Let me know if I missed something that allows me to configure the arguments for spark. However, I did not see this at first inspection. Happy to collaborate more on this if needed. Thanks!