### PR TITLE
Clean up quote values defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ Expect each column value to be in a given set.
 tests:
   - dbt_expectations.expect_column_values_to_be_in_set:
       value_set: ['a','b','c']
-      quote_values: true # (Optional)
+      quote_values: true # (Optional. Default is 'true'.)
       row_condition: "id is not null" # (Optional)
 ```
 
@@ -531,7 +531,7 @@ Expect each column value not to be in a given set.
 tests:
   - dbt_expectations.expect_column_values_to_not_be_in_set:
       value_set: ['e','f','g']
-      quote_values: true # (Optional)
+      quote_values: true # (Optional. Default is 'true'.)
       row_condition: "id is not null" # (Optional)
 ```
 
@@ -723,7 +723,7 @@ Expect the number of distinct column values to be equal to a given value.
 tests:
   - dbt_expectations.expect_column_distinct_count_to_equal:
       value: 10
-      quote_values: false # (Optional. Default is 'false'.)
+      quote_values: true # (Optional. Default is 'true'.)
       group_by: [group_id, other_group_id, ...] # (Optional)
       row_condition: "id is not null" # (Optional)
 ```
@@ -738,7 +738,7 @@ Expect the number of distinct column values to be greater than a given value.
 tests:
   - dbt_expectations.expect_column_distinct_count_to_be_greater_than:
       value: 10
-      quote_values: false # (Optional. Default is 'false'.)
+      quote_values: true # (Optional. Default is 'true'.)
       group_by: [group_id, other_group_id, ...] # (Optional)
       row_condition: "id is not null" # (Optional)
 ```
@@ -753,7 +753,7 @@ Expect the number of distinct column values to be less than a given value.
 tests:
   - dbt_expectations.expect_column_distinct_count_to_be_less_than:
       value: 10
-      quote_values: false # (Optional. Default is 'false'.)
+      quote_values: true # (Optional. Default is 'true'.)
       group_by: [group_id, other_group_id, ...] # (Optional)
       row_condition: "id is not null" # (Optional)
 ```
@@ -768,7 +768,7 @@ Expect the set of distinct column values to be contained by a given set.
 tests:
   - dbt_expectations.expect_column_distinct_values_to_be_in_set:
       value_set: ['a','b','c','d']
-      quote_values: false # (Optional. Default is 'false'.)
+      quote_values: true # (Optional. Default is 'true'.)
       row_condition: "id is not null" # (Optional)
 ```
 
@@ -784,7 +784,7 @@ In contrast to `expect_column_values_to_be_in_set` this ensures not that all col
 tests:
   - dbt_expectations.expect_column_distinct_values_to_contain_set:
       value_set: ['a','b']
-      quote_values: false # (Optional. Default is 'false'.)
+      quote_values: true # (Optional. Default is 'true'.)
       row_condition: "id is not null" # (Optional)
 ```
 
@@ -951,7 +951,7 @@ tests:
   - dbt_expectations.expect_column_most_common_value_to_be_in_set:
       value_set: [0.5]
       top_n: 1
-      quote_values: false # (Optional)
+      quote_values: true # (Optional. Default is 'true'.)
       data_type: "decimal" # (Optional. Default is 'decimal')
       strictly: false # (Optional. Default is 'false'. Adds an 'or equal to' to the comparison operator for min/max)
 ```

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -342,6 +342,7 @@ models:
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: [0.5]
               top_n: 1
+              quote_values: false
           - dbt_expectations.expect_column_values_to_be_increasing:
               sort_column: col_numeric_a
               strictly: false
@@ -357,13 +358,11 @@ models:
               quote_values: true
           - dbt_expectations.expect_column_distinct_values_to_equal_set:
               value_set: ['a','b','c','c']
-              quote_values: true
           - dbt_expectations.expect_column_distinct_values_to_be_in_set:
               value_set: ['a','b','c','d']
               quote_values: true
           - dbt_expectations.expect_column_distinct_values_to_contain_set:
               value_set: ['a','b']
-              quote_values: true
           - dbt_expectations.expect_column_value_lengths_to_equal:
               value: 1
           - dbt_expectations.expect_column_values_to_have_consistent_casing

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_greater_than.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_greater_than.sql
@@ -1,10 +1,9 @@
 {% test expect_column_distinct_count_to_be_greater_than(model,
-                                                                column_name,
-                                                                value,
-                                                                quote_values=False,
-                                                                group_by=None,
-                                                                row_condition=None
-                                                                ) %}
+                                                          column_name,
+                                                          value,
+                                                          group_by=None,
+                                                          row_condition=None
+                                                          ) %}
 {% set expression %}
 count(distinct {{ column_name }}) > {{ value }}
 {% endset %}

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_less_than.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_be_less_than.sql
@@ -1,10 +1,9 @@
 {% test expect_column_distinct_count_to_be_less_than(model,
-                                                                column_name,
-                                                                value,
-                                                                quote_values=False,
-                                                                group_by=None,
-                                                                row_condition=None
-                                                                ) %}
+                                                       column_name,
+                                                       value,
+                                                       group_by=None,
+                                                       row_condition=None
+                                                       ) %}
 {% set expression %}
 count(distinct {{ column_name }}) < {{ value }}
 {% endset %}

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_count_to_equal.sql
@@ -1,10 +1,9 @@
 {% test expect_column_distinct_count_to_equal(model,
-                                                    column_name,
-                                                    value,
-                                                    quote_values=False,
-                                                    group_by=None,
-                                                    row_condition=None
-                                                    ) %}
+                                                column_name,
+                                                value,
+                                                group_by=None,
+                                                row_condition=None
+                                                ) %}
 {% set expression %}
 count(distinct {{ column_name }}) = {{ value }}
 {% endset %}

--- a/macros/schema_tests/aggregate_functions/expect_column_distinct_values_to_be_in_set.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_distinct_values_to_be_in_set.sql
@@ -1,8 +1,9 @@
-{% test expect_column_distinct_values_to_be_in_set(model, column_name,
-                                                    value_set,
-                                                    quote_values=False,
-                                                    row_condition=None
-                                                    ) %}
+{% test expect_column_distinct_values_to_be_in_set(model,
+                                                     column_name,
+                                                     value_set,
+                                                     quote_values=True,
+                                                     row_condition=None
+                                                     ) %}
 
 with all_values as (
 

--- a/macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
@@ -1,20 +1,26 @@
-{% test expect_column_most_common_value_to_be_in_set(model, column_name,
-                                                            value_set,
-                                                            top_n,
-                                                            quote_values=False,
-                                                            data_type="decimal",
-                                                            row_condition=None
-                                                            ) -%}
-    {{ adapter.dispatch('test_expect_column_most_common_value_to_be_in_set', 'dbt_expectations') (model, column_name, value_set, top_n, quote_values, data_type, row_condition) }}
+{% test expect_column_most_common_value_to_be_in_set(model,
+                                                       column_name,
+                                                       value_set,
+                                                       top_n,
+                                                       quote_values=True,
+                                                       data_type="decimal",
+                                                       row_condition=None
+                                                       ) -%}
+
+    {{ adapter.dispatch('test_expect_column_most_common_value_to_be_in_set', 'dbt_expectations') (
+            model, column_name, value_set, top_n, quote_values, data_type, row_condition
+        ) }}
+
 {%- endtest %}
 
-{% macro default__test_expect_column_most_common_value_to_be_in_set(model, column_name,
-                                                            value_set,
-                                                            top_n,
-                                                            quote_values,
-                                                            data_type,
-                                                            row_condition
-                                                            ) %}
+{% macro default__test_expect_column_most_common_value_to_be_in_set(model,
+                                                                      column_name,
+                                                                      value_set,
+                                                                      top_n,
+                                                                      quote_values,
+                                                                      data_type,
+                                                                      row_condition
+                                                                      ) %}
 
 with value_counts as (
 


### PR DESCRIPTION
This aligns defaults for `quote_values`. Also, removes the `quote_values` parameter where it wasn't being used.

Closes #229 