### PR TITLE
Make type macro calls fully qualified

### DIFF
--- a/integration_tests/models/schema_tests/data_test.sql
+++ b/integration_tests/models/schema_tests/data_test.sql
@@ -1,12 +1,12 @@
 select
     1 as idx,
     '2020-10-21' as date_col,
-    cast(0 as {{ type_float() }}) as col_numeric_a,
-    cast(1 as {{ type_float() }}) as col_numeric_b,
+    cast(0 as {{ dbt.type_float() }}) as col_numeric_a,
+    cast(1 as {{ dbt.type_float() }}) as col_numeric_b,
     'a' as col_string_a,
     'b' as col_string_b,
-    cast(null as {{ type_string() }}) as col_null,
-    cast(null as {{ type_string() }}) as col_null_2
+    cast(null as {{ dbt.type_string() }}) as col_null,
+    cast(null as {{ dbt.type_string() }}) as col_null_2
 
 union all
 

--- a/integration_tests/models/schema_tests/timeseries_data.sql
+++ b/integration_tests/models/schema_tests/timeseries_data.sql
@@ -8,8 +8,8 @@ add_row_values as (
     select
         cast(date_day as date) as date_day,
         cast(date_day as {{ dbt_expectations.type_datetime() }}) as date_datetime,
-        cast(date_day as {{ type_timestamp() }}) as date_timestamp,
-        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+        cast(date_day as {{ dbt_expectations.type_timestamp() }}) as date_timestamp,
+        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ dbt.type_float() }}) as row_value
 
     from
         dates

--- a/integration_tests/models/schema_tests/timeseries_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_extended.sql
@@ -8,7 +8,7 @@ add_row_values as (
 
     select
         cast(dates.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
-        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ dbt.type_float() }}) as row_value
 
     from
         dates

--- a/integration_tests/models/schema_tests/timeseries_data_grouped.sql
+++ b/integration_tests/models/schema_tests/timeseries_data_grouped.sql
@@ -12,8 +12,8 @@ add_row_values as (
     select
         cast(dates.date_day as {{ dbt_expectations.type_datetime() }}) as date_day,
         cast(dates.date_day as {{ dbt_expectations.type_timestamp() }}) as date_timestamp,
-        cast(groupings.generated_number as {{ type_int() }}) as group_id,
-        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+        cast(groupings.generated_number as {{ dbt.type_int() }}) as group_id,
+        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ dbt.type_float() }}) as row_value
     from
         dates
         cross join groupings

--- a/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly_data_extended.sql
@@ -10,7 +10,7 @@ add_row_values as (
 
     select
         cast(dates.date_hour as {{ dbt_expectations.type_datetime() }}) as date_hour,
-        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ type_float() }}) as row_value
+        cast(100 * abs({{ dbt_expectations.rand() }}) as {{ dbt.type_float() }}) as row_value
 
     from
         dates

--- a/integration_tests/models/schema_tests/window_function_test.sql
+++ b/integration_tests/models/schema_tests/window_function_test.sql
@@ -3,7 +3,7 @@ with data_example as (
     select
         1 as idx,
         '2020-10-21' as date_col,
-        cast(0 as {{ type_float() }}) as col_numeric_a
+        cast(0 as {{ dbt.type_float() }}) as col_numeric_a
 
     union all
 

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_set.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_set.sql
@@ -20,7 +20,7 @@ set_values as (
     {% for value in value_set -%}
     select
         {% if quote_values -%}
-        cast('{{ value }}' as {{ type_string() }})
+        cast('{{ value }}' as {{ dbt.type_string() }})
         {%- else -%}
         {{ value }}
         {%- endif %} as value_field

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -8,8 +8,8 @@
 
         {% for column in columns_in_relation %}
         select
-            cast('{{ column.name | upper }}' as {{ type_string() }}) as relation_column,
-            cast('{{ column.dtype | upper }}' as {{ type_string() }}) as relation_column_type
+            cast('{{ column.name | upper }}' as {{ dbt.type_string() }}) as relation_column,
+            cast('{{ column.dtype | upper }}' as {{ dbt.type_string() }}) as relation_column_type
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),

--- a/macros/schema_tests/column_values_basic/expect_column_values_to_not_be_in_set.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_not_be_in_set.sql
@@ -20,7 +20,7 @@ set_values as (
     {% for value in value_set -%}
     select
         {% if quote_values -%}
-        cast('{{ value }}' as {{ type_string() }})
+        cast('{{ value }}' as {{ dbt.type_string() }})
         {%- else -%}
         {{ value }}
         {%- endif %} as value_field

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -64,7 +64,7 @@ with metric_values as (
     with grouped_metric_values as (
 
         select
-            {{ date_trunc(period, date_column_name) }} as metric_period,
+            {{ dbt.date_trunc(period, date_column_name) }} as metric_period,
             {{ group_by | join(",") ~ "," if group_by }}
             sum({{ column_name }}) as agg_metric_value
         from
@@ -139,10 +139,10 @@ from
 where
 
     metric_period >= cast(
-            {{ dateadd(period, -test_periods, date_trunc(period, dbt_date.now())) }}
+            {{ dbt.dateadd(period, -test_periods, dbt.date_trunc(period, dbt_date.now())) }}
             as {{ dbt_expectations.type_timestamp() }})
     and
-    metric_period < {{ date_trunc(period, dbt_date.now()) }}
+    metric_period < {{ dbt.date_trunc(period, dbt_date.now()) }}
     and
 
     not (

--- a/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
+++ b/macros/schema_tests/distributional/expect_column_values_to_be_within_n_moving_stdevs.sql
@@ -140,7 +140,7 @@ where
 
     metric_period >= cast(
             {{ dateadd(period, -test_periods, date_trunc(period, dbt_date.now())) }}
-            as {{ type_timestamp() }})
+            as {{ dbt_expectations.type_timestamp() }})
     and
     metric_period < {{ date_trunc(period, dbt_date.now()) }}
     and

--- a/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
+++ b/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
@@ -57,7 +57,7 @@ with base_dates as (
             Filtering the spine only where this remainder == 0 will return a spine with every other day as desired, i.e. [2020-01-01, 2020-01-03, 2020-01-05, ...]
     #}
     where mod(
-            cast({{ datediff("'" ~ start_date ~ "'", 'date_' ~ date_part, date_part) }} as {{ dbt.type_int() }}),
+            cast({{ dbt.datediff("'" ~ start_date ~ "'", 'date_' ~ date_part, date_part) }} as {{ dbt.type_int() }}),
             cast({{interval}} as {{ dbt.type_int() }})
         ) = 0
     {% endif %}
@@ -68,7 +68,7 @@ model_data as (
     select
     {% if not interval %}
 
-        cast({{ date_trunc(date_part, date_col) }} as {{ dbt_expectations.type_datetime() }}) as date_{{ date_part }},
+        cast({{ dbt.date_trunc(date_part, date_col) }} as {{ dbt_expectations.type_datetime() }}) as date_{{ date_part }},
 
     {% else %}
         {#
@@ -80,13 +80,13 @@ model_data as (
                 subtracting that number of days from the observations will produce records [2020-01-01, 2020-01-01, 2020-01-03, 2020-01-11, 2020-01-11],
                 all of which align with records from the interval-date spine
         #}
-        {{dateadd(
+        {{ dbt.dateadd(
             date_part,
             "mod(
                 cast(" ~ datediff("'" ~ start_date ~ "'", date_col, date_part) ~ " as " ~ dbt.type_int() ~ " ),
                 cast(" ~ interval ~ " as  " ~ dbt.type_int() ~ " )
             ) * (-1)",
-            "cast( " ~ date_trunc(date_part, date_col) ~ " as  " ~ dbt_expectations.type_datetime() ~ ")"
+            "cast( " ~ dbt.date_trunc(date_part, date_col) ~ " as  " ~ dbt_expectations.type_datetime() ~ ")"
         )}} as date_{{ date_part }},
 
     {% endif %}

--- a/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
+++ b/macros/schema_tests/distributional/expect_row_values_to_have_data_for_every_n_datepart.sql
@@ -57,8 +57,8 @@ with base_dates as (
             Filtering the spine only where this remainder == 0 will return a spine with every other day as desired, i.e. [2020-01-01, 2020-01-03, 2020-01-05, ...]
     #}
     where mod(
-            cast({{ datediff("'" ~ start_date ~ "'", 'date_' ~ date_part, date_part) }} as {{ type_int() }}),
-            cast({{interval}} as {{ type_int() }})
+            cast({{ datediff("'" ~ start_date ~ "'", 'date_' ~ date_part, date_part) }} as {{ dbt.type_int() }}),
+            cast({{interval}} as {{ dbt.type_int() }})
         ) = 0
     {% endif %}
 
@@ -83,8 +83,8 @@ model_data as (
         {{dateadd(
             date_part,
             "mod(
-                cast(" ~ datediff("'" ~ start_date ~ "'", date_col, date_part) ~ " as " ~ type_int() ~ " ),
-                cast(" ~ interval ~ " as  " ~ type_int() ~ " )
+                cast(" ~ datediff("'" ~ start_date ~ "'", date_col, date_part) ~ " as " ~ dbt.type_int() ~ " ),
+                cast(" ~ interval ~ " as  " ~ dbt.type_int() ~ " )
             ) * (-1)",
             "cast( " ~ date_trunc(date_part, date_col) ~ " as  " ~ dbt_expectations.type_datetime() ~ ")"
         )}} as date_{{ date_part }},

--- a/macros/schema_tests/table_shape/expect_column_to_exist.sql
+++ b/macros/schema_tests/table_shape/expect_column_to_exist.sql
@@ -21,7 +21,7 @@
     with test_data as (
 
         select
-            cast('{{ column_name }}' as {{ type_string() }}) as column_name,
+            cast('{{ column_name }}' as {{ dbt.type_string() }}) as column_name,
             {{ matching_column_index }} as matching_column_index,
             {{ column_index_matches }} as column_index_matches
 

--- a/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -62,7 +62,7 @@ outdated_grouped_timestamps as (
         -- are the max timestamps per group older than the specified cutoff?
         latest_timestamp_column <
             cast(
-                {{ dateadd(datepart, interval * -1, dbt_date.now()) }}
+                {{ dbt.dateadd(datepart, interval * -1, dbt_date.now()) }}
                 as {{ dbt_expectations.type_timestamp() }}
             )
 

--- a/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_grouped_row_values_to_have_recent_data.sql
@@ -25,12 +25,12 @@ with latest_grouped_timestamps as (
     select
         {{ group_by | join(",") ~ "," if group_by }}
         max(1) as join_key,
-        max(cast({{ timestamp_column }} as {{ type_timestamp() }})) as latest_timestamp_column
+        max(cast({{ timestamp_column }} as {{ dbt_expectations.type_timestamp() }})) as latest_timestamp_column
     from
         {{ model }}
     where
         -- to exclude erroneous future dates
-        cast({{ timestamp_column }} as {{ type_timestamp() }}) <= {{ dbt_date.now() }}
+        cast({{ timestamp_column }} as {{ dbt_expectations.type_timestamp() }}) <= {{ dbt_date.now() }}
         {% if row_condition %}
         and {{ row_condition }}
         {% endif %}
@@ -63,7 +63,7 @@ outdated_grouped_timestamps as (
         latest_timestamp_column <
             cast(
                 {{ dateadd(datepart, interval * -1, dbt_date.now()) }}
-                as {{ type_timestamp() }}
+                as {{ dbt_expectations.type_timestamp() }}
             )
 
 ),

--- a/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
@@ -16,12 +16,12 @@
 {%- set default_start_date = '1970-01-01' -%}
 with max_recency as (
 
-    select max(cast({{ column_name }} as {{ type_timestamp() }})) as max_timestamp
+    select max(cast({{ column_name }} as {{ dbt_expectations.type_timestamp() }})) as max_timestamp
     from
         {{ model }}
     where
         -- to exclude erroneous future dates
-        cast({{ column_name }} as {{ type_timestamp() }}) <= {{ dbt_date.now() }}
+        cast({{ column_name }} as {{ dbt_expectations.type_timestamp() }}) <= {{ dbt_date.now() }}
         {% if row_condition %}
         and {{ row_condition }}
         {% endif %}
@@ -33,8 +33,8 @@ from
 where
     -- if the row_condition excludes all rows, we need to compare against a default date
     -- to avoid false negatives
-    coalesce(max_timestamp, cast('{{ default_start_date }}' as {{ type_timestamp() }}))
+    coalesce(max_timestamp, cast('{{ default_start_date }}' as {{ dbt_expectations.type_timestamp() }}))
         <
-        cast({{ dateadd(datepart, interval * -1, dbt_date.now()) }} as {{ type_timestamp() }})
+        cast({{ dateadd(datepart, interval * -1, dbt_date.now()) }} as {{ dbt_expectations.type_timestamp() }})
 
 {% endmacro %}

--- a/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
+++ b/macros/schema_tests/table_shape/expect_row_values_to_have_recent_data.sql
@@ -35,6 +35,6 @@ where
     -- to avoid false negatives
     coalesce(max_timestamp, cast('{{ default_start_date }}' as {{ dbt_expectations.type_timestamp() }}))
         <
-        cast({{ dateadd(datepart, interval * -1, dbt_date.now()) }} as {{ dbt_expectations.type_timestamp() }})
+        cast({{ dbt.dateadd(datepart, interval * -1, dbt_date.now()) }} as {{ dbt_expectations.type_timestamp() }})
 
 {% endmacro %}

--- a/macros/schema_tests/table_shape/expect_table_columns_to_contain_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_contain_set.sql
@@ -6,14 +6,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select cast('{{ col_name }}' as {{ type_string() }}) as relation_column
+        select cast('{{ col_name }}' as {{ dbt.type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select cast('{{ col_name }}' as {{ type_string() }}) as input_column
+        select cast('{{ col_name }}' as {{ dbt.type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_ordered_list.sql
@@ -8,7 +8,7 @@
         {% for col_name in relation_column_names %}
         select
             {{ loop.index }} as relation_column_idx,
-            cast('{{ col_name }}' as {{ type_string() }}) as relation_column
+            cast('{{ col_name }}' as {{ dbt.type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
@@ -17,7 +17,7 @@
         {% for col_name in column_list %}
         select
             {{ loop.index }} as input_column_idx,
-            cast('{{ col_name }}' as {{ type_string() }}) as input_column
+            cast('{{ col_name }}' as {{ dbt.type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_match_set.sql
@@ -6,14 +6,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select cast('{{ col_name }}' as {{ type_string() }}) as relation_column
+        select cast('{{ col_name }}' as {{ dbt.type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select cast('{{ col_name }}' as {{ type_string() }}) as input_column
+        select cast('{{ col_name }}' as {{ dbt.type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )

--- a/macros/schema_tests/table_shape/expect_table_columns_to_not_contain_set.sql
+++ b/macros/schema_tests/table_shape/expect_table_columns_to_not_contain_set.sql
@@ -6,14 +6,14 @@
     with relation_columns as (
 
         {% for col_name in relation_column_names %}
-        select cast('{{ col_name }}' as {{ type_string() }}) as relation_column
+        select cast('{{ col_name }}' as {{ dbt.type_string() }}) as relation_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     ),
     input_columns as (
 
         {% for col_name in column_list %}
-        select cast('{{ col_name }}' as {{ type_string() }}) as input_column
+        select cast('{{ col_name }}' as {{ dbt.type_string() }}) as input_column
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
     )


### PR DESCRIPTION
Fixes #230 

This PR makes calls to `type_*` macros fully qualified, e.g. `dbt_expectations.type_timestamp()` and `dbt.type_string()` to avoid namespace collisions with legacy macros in dbt_utils.

cc: @Maayan-s @elongl