### PR TITLE
Escaping single quotes in column names

### DIFF
--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -8,7 +8,7 @@
 
         {% for column in columns_in_relation %}
         select
-            cast('{{ column.name | upper }}' as {{ dbt.type_string() }}) as relation_column,
+            cast('{{ escape_single_quotes(column.name) | upper }}' as {{ dbt.type_string() }}) as relation_column,
             cast('{{ column.dtype | upper }}' as {{ dbt.type_string() }}) as relation_column_type
         {% if not loop.last %}union all{% endif %}
         {% endfor %}
@@ -20,7 +20,7 @@
         from
             relation_columns
         where
-            relation_column = '{{ column_name }}'
+            relation_column = '{{ escape_single_quotes(column_name) }}'
             and
             relation_column_type not in ('{{ column_type_list | join("', '") }}')
 


### PR DESCRIPTION
There's probably other places where this applies
I've had this problem with trino, not sure if this applies to different DBs (do other DBs even allow for column names to have single quotes?)
If this needs to be supported, probably a good idea to include some crazy column names in the tests