### PR TITLE
Fix postgres__regexp_instr not validating regex #249

### DIFF
--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -4,18 +4,22 @@ models:
     columns:
       - name: email_address
         tests:
+            # match email address
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "@[^.]*"
+            # does not match email address, should fail
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "&[^.]*"
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # match all uppercase, but match case-insensitive (where implemented)
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "[A-Z]"
               flags: i
               config:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+            # match all uppercase, case-sensitive (where implemented), should fail
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "[A-Z]"
               flags: c
@@ -23,32 +27,40 @@ models:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
                 error_if: "=0"
                 warn_if: "<4"
+            # do not match other non-email string, should pass
           - dbt_expectations.expect_column_values_to_not_match_regex:
               regex: "&[^.]*"
+            # match email address, should fail
           - dbt_expectations.expect_column_values_to_not_match_regex:
               regex: "@[^.]*"
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # match all uppercase, case-sensitive (default), should pass
           - dbt_expectations.expect_column_values_to_not_match_regex:
               regex: "[A-Z]"
+            # match all lowercase, case-sensitive (default), should fail
           - dbt_expectations.expect_column_values_to_not_match_regex:
               regex: "[a-z]"
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # do match one of email address or other non-email string
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["@[^.]*", "&[^.]*"]
+            # do not match other non-email strings, should fail
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["#[^.]*", "&[^.]*"]
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # match all uppercase, but match case-insensitive (where implemented)
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
               flags: i
               config:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+            # match all uppercase, but match case-sensitive (where implemented), should fail
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
               flags: c
@@ -56,58 +68,76 @@ models:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
                 error_if: "=0"
                 warn_if: "<4"
+            # match email address or other string
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["@[^.]*", "&[^.]*"]
+            # match email address, should fail
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["@[^.]*", "@[^.]*"]
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # do not match any of other non-email string
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["&[^.]*", "&[^.]*"]
               match_on: all
+            # do not match any of email or other non-email string, should fail
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["@[^.]*", "&[^.]*"]
               match_on: all
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # do not match all uppercase
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
+            # do not match all uppercase or numbers, case-insensitive (where implemented)
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-Z]", "[0-9]"]
               flags: i
+              config:
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+            # do not match all uppercase and numbers, case-insensitive (where implemented)
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-Z]", "[0-9]"]
               flags: i
               match_on: all
               config:
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
                 error_if: "=0"
                 warn_if: "<4"
+            # match '@' anywhere in string
           - dbt_expectations.expect_column_values_to_match_like_pattern:
               like_pattern: "%@%"
+            # match '&' anywhere in string, should fail
           - dbt_expectations.expect_column_values_to_match_like_pattern:
               like_pattern: "%&%"
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # do not match '&' anywhere in string
           - dbt_expectations.expect_column_values_to_not_match_like_pattern:
               like_pattern: "%&%"
+            # do not match '@' anywhere in string, should fail
           - dbt_expectations.expect_column_values_to_not_match_like_pattern:
               like_pattern: "%@%"
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # match at least one of '@' or '&' anywhere in string
           - dbt_expectations.expect_column_values_to_match_like_pattern_list:
               like_pattern_list: ["%@%", "%&%"]
+            # match both '@' or '&' anywhere in string, should fail
           - dbt_expectations.expect_column_values_to_match_like_pattern_list:
               like_pattern_list: ["%@%", "%&%"]
               match_on: all
               config:
                 error_if: "=0"
                 warn_if: "<4"
+            # do not match at least one of '@' or '&' anywhere in string
           - dbt_expectations.expect_column_values_to_not_match_like_pattern_list:
               like_pattern_list: ["%@%", "%&%"]
+            # do not match either of '@' or '&' anywhere in string, should fail
           - dbt_expectations.expect_column_values_to_not_match_like_pattern_list:
               like_pattern_list: ["%@%", "%&%"]
               match_on: all

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -17,8 +17,8 @@ models:
               config:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
           - dbt_expectations.expect_column_values_to_match_regex:
-              regex: "&[^.]*"
-              flags: i
+              regex: "[A-Z]"
+              flags: c
               config:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
                 error_if: "=0"
@@ -33,8 +33,7 @@ models:
           - dbt_expectations.expect_column_values_to_not_match_regex:
               regex: "[A-Z]"
           - dbt_expectations.expect_column_values_to_not_match_regex:
-              regex: "[A-Z]"
-              flags: i
+              regex: "[a-z]"
               config:
                 error_if: "=0"
                 warn_if: "<4"
@@ -51,8 +50,8 @@ models:
               config:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
           - dbt_expectations.expect_column_values_to_match_regex_list:
-              regex_list: ["![A-G]", "![H-Z]"]
-              flags: i
+              regex_list: ["[A-G]", "[H-Z]"]
+              flags: c
               config:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
                 error_if: "=0"
@@ -76,10 +75,10 @@ models:
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
-              regex_list: ["[N-Q]", "[R-Z]"]
+              regex_list: ["[A-Z]", "[0-9]"]
               flags: i
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
-              regex_list: ["[A-G]", "[N-Q]", "[R-Z]"]
+              regex_list: ["[A-Z]", "[0-9]"]
               flags: i
               match_on: all
               config:

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -7,52 +7,171 @@ models:
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "@[^.]*"
           - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "&[^.]*"
+              config:
+                error_if: "=0"
+                warn_if: "<4"
+          - dbt_expectations.expect_column_values_to_match_regex:
               regex: "[A-Z]"
               flags: i
               config:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "&[^.]*"
+              flags: i
+              config:
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_not_match_regex:
               regex: "&[^.]*"
           - dbt_expectations.expect_column_values_to_not_match_regex:
+              regex: "@[^.]*"
+              config:
+                error_if: "=0"
+                warn_if: "<4"
+          - dbt_expectations.expect_column_values_to_not_match_regex:
               regex: "[A-Z]"
+          - dbt_expectations.expect_column_values_to_not_match_regex:
+              regex: "[A-Z]"
+              flags: i
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["@[^.]*", "&[^.]*"]
+          - dbt_expectations.expect_column_values_to_match_regex_list:
+              regex_list: ["#[^.]*", "&[^.]*"]
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
               flags: i
               config:
                 enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+          - dbt_expectations.expect_column_values_to_match_regex_list:
+              regex_list: ["![A-G]", "![H-Z]"]
+              flags: i
+              config:
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["@[^.]*", "&[^.]*"]
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
+              regex_list: ["@[^.]*", "@[^.]*"]
+              config:
+                error_if: "=0"
+                warn_if: "<4"
+          - dbt_expectations.expect_column_values_to_not_match_regex_list:
+              regex_list: ["&[^.]*", "&[^.]*"]
+              match_on: all
+          - dbt_expectations.expect_column_values_to_not_match_regex_list:
+              regex_list: ["@[^.]*", "&[^.]*"]
+              match_on: all
+              config:
+                error_if: "=0"
+                warn_if: "<4"
+          - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
+          - dbt_expectations.expect_column_values_to_not_match_regex_list:
+              regex_list: ["[N-Q]", "[R-Z]"]
+              flags: i
+          - dbt_expectations.expect_column_values_to_not_match_regex_list:
+              regex_list: ["[A-G]", "[N-Q]", "[R-Z]"]
+              flags: i
+              match_on: all
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_match_like_pattern:
               like_pattern: "%@%"
+          - dbt_expectations.expect_column_values_to_match_like_pattern:
+              like_pattern: "%&%"
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_not_match_like_pattern:
               like_pattern: "%&%"
+          - dbt_expectations.expect_column_values_to_not_match_like_pattern:
+              like_pattern: "%@%"
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_match_like_pattern_list:
+              like_pattern_list: ["%@%", "%&%"]
+          - dbt_expectations.expect_column_values_to_match_like_pattern_list:
+              like_pattern_list: ["%@%", "%&%"]
+              match_on: all
+              config:
+                error_if: "=0"
+                warn_if: "<4"
+          - dbt_expectations.expect_column_values_to_not_match_like_pattern_list:
               like_pattern_list: ["%@%", "%&%"]
           - dbt_expectations.expect_column_values_to_not_match_like_pattern_list:
               like_pattern_list: ["%@%", "%&%"]
+              match_on: all
+              config:
+                error_if: "=0"
+                warn_if: "<4"
       - name: postal_code_5
         tests:
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "^\\d{5}"
               is_raw: True
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "^\\d{55}"
+              is_raw: True
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_not_match_regex:
               regex: "@[^.]*"
               is_raw: True
+          - dbt_expectations.expect_column_values_to_not_match_regex:
+              regex: "^\\d{5}"
+              is_raw: True
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["^\\d{5}"]
               is_raw: True
+          - dbt_expectations.expect_column_values_to_match_regex_list:
+              regex_list: ["^\\d{5}", "@[^.]*"]
+              is_raw: True
+          - dbt_expectations.expect_column_values_to_match_regex_list:
+              regex_list: ["^\\d{5}", "@[^.]*"]
+              is_raw: True
+              match_on: all
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["@[^.]*"]
               is_raw: True
+          - dbt_expectations.expect_column_values_to_not_match_regex_list:
+              regex_list: ["^\\d{5}", "@[^.]*"]
+              is_raw: True
+          - dbt_expectations.expect_column_values_to_not_match_regex_list:
+              regex_list: ["^\\d{5}", "@[^.]*"]
+              is_raw: True
+              match_on: all
+              config:
+                error_if: "=0"
+                warn_if: "<4"
       - name: postal_code_5_3
         tests:
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "^\\d{5}-\\d{3}"
               is_raw: True
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "^\\d{5}-\\d{9}"
+              is_raw: True
+              config:
+                error_if: "=0"
+                warn_if: "<4"
 
 
   - name: timeseries_data

--- a/macros/regex/regexp_instr.sql
+++ b/macros/regex/regexp_instr.sql
@@ -38,7 +38,7 @@ regexp_instr({{ source_value }}, {{ regexp }}, {{ position }}, {{ occurrence }})
 {# Postgres does not need to escape raw strings #}
 {% macro postgres__regexp_instr(source_value, regexp, position, occurrence, is_raw, flags) %}
 {% if flags %}{{ dbt_expectations._validate_flags(flags, 'bcegimnpqstwx') }}{% endif %}
-array_length((select regexp_matches({{ source_value }}, '{{ regexp }}', '{{ flags }}')), 1)
+coalesce(array_length((select regexp_matches({{ source_value }}, '{{ regexp }}', '{{ flags }}')), 1), 0)
 {% endmacro %}
 
 {# Unclear what Redshift does to escape raw strings #}


### PR DESCRIPTION
## What does this PR do?
Fix regex match succeeding for any pattern in Postgres (#249)
Add expected-to-fail tests for regex (#207)

## Change description
Coalesce array_length and 0 to avoid null in expression when no match exists resulting in always falsy `WHERE` condition on error check in tests.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Where has this been tested?
- OS: Manjaro Linux 22.0.2
- Python: 3.10.9
- dbt: 1.4.5
- dbt-expectations: 0.8.3
- PostgreSQL: 14.6