### PR TITLE
escape quotes in expect_column_values_to_be_in_type_list.sql

### DIFF
--- a/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
+++ b/macros/schema_tests/column_values_basic/expect_column_values_to_be_in_type_list.sql
@@ -8,7 +8,7 @@
 
         {% for column in columns_in_relation %}
         select
-            cast('{{ column.name | upper }}' as {{ dbt.type_string() }}) as relation_column,
+            cast('{{ escape_single_quotes(column.name | upper) }}' as {{ dbt.type_string() }}) as relation_column,
             cast('{{ column.dtype | upper }}' as {{ dbt.type_string() }}) as relation_column_type
         {% if not loop.last %}union all{% endif %}
         {% endfor %}


### PR DESCRIPTION
I have column names with apostrophes (unfortunately).
Adding this escaper makes stuff work.