### PR TITLE
Add support for regex flags for BigQuery

### DIFF
--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -18,7 +18,14 @@ models:
               regex: "[A-Z]"
               flags: i
               config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
+            # match all uppercase with inline case-insensitive flag and case-insensitive flag parameter (where implemented)
+            # check that adapters handling flags by inlining them don't break because of the flag duplication
+          - dbt_expectations.expect_column_values_to_match_regex:
+              regex: "(?i)[A-Z]"
+              flags: i
+              config:
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
             # match all uppercase, case-sensitive (where implemented), should fail
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "[A-Z]"
@@ -59,7 +66,7 @@ models:
               regex_list: ["[A-G]", "[H-Z]"]
               flags: i
               config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
             # match all uppercase, but match case-sensitive (where implemented), should fail
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
@@ -96,15 +103,14 @@ models:
               regex_list: ["[A-Z]", "[0-9]"]
               flags: i
               config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
             # do not match all uppercase and numbers, case-insensitive (where implemented)
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-Z]", "[0-9]"]
               flags: i
               match_on: all
               config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift' ] }}"
+                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
                 error_if: "=0"
                 warn_if: "<4"
             # match '@' anywhere in string

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -25,7 +25,7 @@ models:
               regex: "(?i)[A-Z]"
               flags: i
               config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
+                enabled: "{{ target.type == 'bigquery' }}"
             # match all uppercase, case-sensitive (where implemented), should fail
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "[A-Z]"

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -13,12 +13,10 @@ models:
               config:
                 error_if: "=0"
                 warn_if: "<4"
-            # match all uppercase, but match case-insensitive (where implemented)
+            # match all uppercase, but match case-insensitive
           - dbt_expectations.expect_column_values_to_match_regex:
               regex: "[A-Z]"
               flags: i
-              config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
             # match all uppercase with inline case-insensitive flag and case-insensitive flag parameter (where implemented)
             # check that adapters handling flags by inlining them don't break because of the flag duplication
           - dbt_expectations.expect_column_values_to_match_regex:
@@ -61,12 +59,10 @@ models:
               config:
                 error_if: "=0"
                 warn_if: "<4"
-            # match all uppercase, but match case-insensitive (where implemented)
+            # match all uppercase, but match case-insensitive
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
               flags: i
-              config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
             # match all uppercase, but match case-sensitive (where implemented), should fail
           - dbt_expectations.expect_column_values_to_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
@@ -98,19 +94,16 @@ models:
             # do not match all uppercase
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-G]", "[H-Z]"]
-            # do not match all uppercase or numbers, case-insensitive (where implemented)
+            # do not match all uppercase or numbers, case-insensitive
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-Z]", "[0-9]"]
               flags: i
-              config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
-            # do not match all uppercase and numbers, case-insensitive (where implemented)
+            # do not match all uppercase and numbers, case-insensitive
           - dbt_expectations.expect_column_values_to_not_match_regex_list:
               regex_list: ["[A-Z]", "[0-9]"]
               flags: i
               match_on: all
               config:
-                enabled: "{{ target.type in ['postgres', 'snowflake', 'redshift', 'bigquery' ] }}"
                 error_if: "=0"
                 warn_if: "<4"
             # match '@' anywhere in string

--- a/macros/regex/regexp_instr.sql
+++ b/macros/regex/regexp_instr.sql
@@ -27,9 +27,9 @@ regexp_instr({{ source_value }}, {{ regexp }}, {{ position }}, {{ occurrence }},
 {# BigQuery uses "r" to escape raw strings #}
 {% macro bigquery__regexp_instr(source_value, regexp, position, occurrence, is_raw, flags) %}
 {% if flags %}
-    {{ exceptions.warn(
-            "The flags option is not supported for BigQuery and is being ignored."
-    ) }}
+    {{ dbt_expectations._validate_re2_flags(flags) }}
+    {# BigQuery prepends "(?flags)" to set flags for current group #}
+    {%- set regexp = "(?" ~ flags ~ ")" ~ regexp -%}
 {% endif %}
 {%- set regexp = "r'" ~ regexp ~ "'" if is_raw else "'" ~ regexp ~ "'" -%}
 regexp_instr({{ source_value }}, {{ regexp }}, {{ position }}, {{ occurrence }})
@@ -50,9 +50,31 @@ regexp_instr({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }
 {% macro _validate_flags(flags, alphabet) %}
 {% for flag in flags %}
     {% if flag not in alphabet %}
-    {{ exceptions.raise_compiler_error(
+    {# Using raise_compiler_error causes disabled tests with invalid flags to fail compilation #}
+    {{ exceptions.warn(
         "flag " ~ flag ~ " not in list of allowed flags for this adapter: " ~ alphabet | join(", ")
     ) }}
     {% endif %}
 {% endfor %}
+{% endmacro %}
+
+{# Re2 requires specific flag validation because of its clear flag operator #}
+{% macro _validate_re2_flags(flags) %}
+{# Re2 supports following flags: #}
+{# i  :  case-insensitive (default fault) #}
+{# m  :  multi-line mode: ^ and $ match begin/end line in addition to begin/end text (default false) #}
+{# s  :  let . match \n (default false) #}
+{# U  :  ungreedy: swap meaning of x* and x*?, x+ and x+?, etc (default false) #}
+{# Flag syntax is xyz (set) or -xyz (clear) or xy-z (set xy, clear z).  #}
+
+{# Regex explanation: do not allow consecutive dashes, accept all re2 flags and clear operator, do not end with a dash  #}
+{% set re2_flags_pattern = '^(?!.*--)[-imsU]*(?<!-)$' %}
+{% set re = modules.re %}
+{% set is_match = re.match(re2_flags_pattern, flags) %}
+{% if not is_match %}
+    {# Using raise_compiler_error causes disabled tests with invalid flags to fail compilation #}
+    {{ exceptions.warn(
+        "flags " ~ flags ~ " isn't a valid re2 flag pattern" 
+    ) }}
+{% endif %}
 {% endmacro %}


### PR DESCRIPTION
## What does this PR do?
Add support for regex flags for BigQuery (#252)

## Change description
Inline flags in non-capturing block 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Where has this been tested?
- OS: Manjaro Linux 22.0.2
- Python: 3.10.9
- dbt: 1.4.5
- dbt-expectations: 0.8.3
- dbt-bigquery: 1.4.3