### PR TITLE
Expect table column names and dtypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,15 +283,16 @@ Expect the names and dtypes of the columns in a model to match provided a Python
 *Applies to:* Model, Seed, Source
 
 ```yaml
-models: # or seeds:
-  - name: my_model
-    tests:
-      - dbt_expectations.expect_table_column_names_and_dtypes:
-          mapping:
-             name: VARCHAR
-             birthday: DATE
-             age_in_years: INTEGER
-
+sources:
+  - name: my_source
+    tables:
+      - name: my_table
+        tests:
+          - dbt_expectations.expect_table_column_names_and_dtypes:
+              mapping:
+                 name: VARCHAR
+                 birthday: DATE
+                 age_in_years: INTEGER
 ```
 
 ### [expect_table_columns_to_not_contain_set](macros/schema_tests/table_shape/expect_table_columns_to_not_contain_set.sql)

--- a/README.md
+++ b/README.md
@@ -287,11 +287,11 @@ models: # or seeds:
   - name: my_model
     tests:
       - dbt_expectations.expect_table_column_names_and_dtypes:
-          mapping: {
-             'NAME': 'VARCHAR',
-             'BIRTHDAY': 'DATE',
-             'AGE_IN_YEARS': 'INTEGER',
-          }
+          mapping:
+             name: VARCHAR
+             birthday: DATE
+             age_in_years: INTEGER
+
 ```
 
 ### [expect_table_columns_to_not_contain_set](macros/schema_tests/table_shape/expect_table_columns_to_not_contain_set.sql)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ For example, use `America/New_York` for East Coast Time.
 - [expect_table_column_count_to_be_between](#expect_table_column_count_to_be_between)
 - [expect_table_column_count_to_equal_other_table](#expect_table_column_count_to_equal_other_table)
 - [expect_table_column_count_to_equal](#expect_table_column_count_to_equal)
+- [expect_table_column_names_and_dtypes](#expect_table_column_names_and_dtypes)
 - [expect_table_columns_to_not_contain_set](#expect_table_columns_to_not_contain_set)
 - [expect_table_columns_to_contain_set](#expect_table_columns_to_contain_set)
 - [expect_table_columns_to_match_ordered_list](#expect_table_columns_to_match_ordered_list)
@@ -273,6 +274,24 @@ models: # or seeds:
     tests:
       - dbt_expectations.expect_table_column_count_to_equal_other_table:
           compare_model: ref("other_model")
+```
+
+### [expect_table_column_names_and_dtypes](macros/schema_tests/table_shape/expect_table_column_names_and_dtypes.sql)
+
+Expect the names and dtypes of the columns in a model to match provided a Python dict.
+
+*Applies to:* Model, Seed, Source
+
+```yaml
+models: # or seeds:
+  - name: my_model
+    tests:
+      - dbt_expectations.expect_table_column_names_and_dtypes:
+          mapping: {
+             'NAME': 'VARCHAR',
+             'BIRTHDAY': 'DATE',
+             'AGE_IN_YEARS': 'INTEGER',
+          }
 ```
 
 ### [expect_table_columns_to_not_contain_set](macros/schema_tests/table_shape/expect_table_columns_to_not_contain_set.sql)

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -248,6 +248,8 @@ models:
           column_list: ["idx", "date_col", "col_numeric_a", "col_numeric_b", "col_string_a", "col_string_b", "col_null", "col_null_2"]
       - dbt_expectations.expect_table_column_count_to_equal_other_table:
           compare_model: ref("data_test")
+      - dbt_expectations.expect_table_column_names_and_dtypes:
+          mapping: {'date_col': 'DATE', 'col_string_b': 'STRING'}
       - dbt_expectations.expect_table_columns_to_not_contain_set:
           column_list: ["col_numeric_c", "col_string_d"]
       - dbt_expectations.expression_is_true:

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -249,7 +249,9 @@ models:
       - dbt_expectations.expect_table_column_count_to_equal_other_table:
           compare_model: ref("data_test")
       - dbt_expectations.expect_table_column_names_and_dtypes:
-          mapping: {'date_col': 'DATE', 'col_string_b': 'STRING'}
+          mapping:
+            date_col: DATE
+            col_string_b: STRING
       - dbt_expectations.expect_table_columns_to_not_contain_set:
           column_list: ["col_numeric_c", "col_string_d"]
       - dbt_expectations.expression_is_true:

--- a/macros/schema_tests/table_shape/expect_table_column_names_and_dtypes.sql
+++ b/macros/schema_tests/table_shape/expect_table_column_names_and_dtypes.sql
@@ -1,0 +1,45 @@
+{%- test expect_table_column_names_and_dtypes(model, mapping) -%}
+{%- if execute -%}
+
+    {%- set columns_in_relation = adapter.get_columns_in_relation(model) -%}
+
+    WITH relation AS (
+        {% for column in columns_in_relation %}
+        SELECT
+            CAST('{{ escape_single_quotes(column.name | upper) }}' AS {{ dbt.type_string() }}) AS relation_column_name,
+            CAST('{{ column.dtype | upper }}' AS {{ dbt.type_string() }})                      AS relation_column_type
+        {% if not loop.last %}UNION ALL{% endif %}
+        {% endfor %}
+    ),
+
+    expected AS (
+        {% for expected_column_name, expected_column_type in mapping.items() %}
+        SELECT
+            CAST('{{ escape_single_quotes(expected_column_name | upper) }}' AS {{ dbt.type_string() }}) AS expected_column_name,
+            CAST('{{ expected_column_type | upper }}' AS {{ dbt.type_string() }})                       AS expected_column_type
+        {% if not loop.last %}UNION ALL{% endif %}
+        {% endfor %}
+    ),
+
+    a_minus_b as (
+        select * from relation
+        except
+        select * from expected
+    ),
+
+    b_minus_a as (
+        select * from expected
+        except
+        select * from relation
+    ),
+
+    unioned as (
+        select 'relation' as found_in, * from a_minus_b
+        union all
+        select 'expected' as found_in, * from b_minus_a
+    )
+
+    select * from unioned
+
+{%- endif -%}
+{%- endtest -%}


### PR DESCRIPTION
This PR creates a schema test which will directly compare the `column name : data type` mapping of the relation with a given python dictionary.

After comparing upper cased column names and data types, it will run an EXCEPT/UNION difference type query which will return any differences found between the two mappings and returns rows containing the difference and a `found_in` column explaining the error

![image](https://user-images.githubusercontent.com/22686431/231826904-34d01be2-1204-46bf-a835-1b6cf4cf6ce0.png)

This is intended to be a complete coverage for schema changes in place more verbose workarounds like this https://madisonmae.substack.com/p/tutorial-using-dbt-to-test-for-schema