### PR TITLE
Fix expect_column_most_common_value_to_be_in_set handling of ties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,10 +1009,12 @@ tests:
       value_set: [0.5]
       top_n: 1
       quote_values: true # (Optional. Default is 'true'.)
-      data_type: "decimal" # (Optional. Default is 'decimal')
+      data_type: "decimal"  # (Optional. Default is adapter-specific equivalent of 'decimal' with a scale provided by dbt. 
+                            # Using decimal/numeric without scale might result in unexpected behaviour with Snowflake where scale
+                            # defaults to 0 resulting in values being rounded)
       strictly: false # (Optional. Default is 'false'. Adds an 'or equal to' to the comparison operator for min/max)
-      ties_okay: true # (Optional. Default is 'false'. If true, the expectation will succeed if values outside 
-                      # the designated set are as common (but not more common) than designated values)
+      allow_ties: true # (Optional. Default is 'false'. If true, the expectation will succeed if values outside 
+                       # the designated set are as common (but not more common) than designated values)
 ```
 
 ### [expect_column_max_to_be_between](macros/schema_tests/aggregate_functions/expect_column_max_to_be_between.sql)

--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,8 @@ tests:
       quote_values: true # (Optional. Default is 'true'.)
       data_type: "decimal" # (Optional. Default is 'decimal')
       strictly: false # (Optional. Default is 'false'. Adds an 'or equal to' to the comparison operator for min/max)
+      ties_okay: true # (Optional. Default is 'false'. If true, the expectation will succeed if values outside 
+                      # the designated set are as common (but not more common) than designated values)
 ```
 
 ### [expect_column_max_to_be_between](macros/schema_tests/aggregate_functions/expect_column_max_to_be_between.sql)

--- a/README.md
+++ b/README.md
@@ -1013,7 +1013,7 @@ tests:
                             # Using decimal/numeric without scale might result in unexpected behaviour with Snowflake where scale
                             # defaults to 0 resulting in values being rounded)
       strictly: false # (Optional. Default is 'false'. Adds an 'or equal to' to the comparison operator for min/max)
-      allow_ties: true # (Optional. Default is 'false'. If true, the expectation will succeed if values outside 
+      ties_okay: true # (Optional. Default is 'false'. If true, the expectation will succeed if values outside 
                        # the designated set are as common (but not more common) than designated values)
 ```
 

--- a/integration_tests/models/schema_tests/data_test.sql
+++ b/integration_tests/models/schema_tests/data_test.sql
@@ -13,8 +13,8 @@ union all
 select
     2 as idx,
     '2020-10-22' as date_col,
-    1 as col_numeric_a,
-    0 as col_numeric_b,
+    cast(1 as {{ dbt.type_numeric() }}) as col_numeric_a,
+    cast(0 as {{ dbt.type_numeric() }}) as col_numeric_b,
     'b' as col_string_a,
     'ab' as col_string_b,
     null as col_null,
@@ -25,8 +25,8 @@ union all
 select
     3 as idx,
     '2020-10-23' as date_col,
-    0.5 as col_numeric_a,
-    0.5 as col_numeric_b,
+    cast(0.5 as {{ dbt.type_numeric() }}) as col_numeric_a,
+    cast(0.5 as {{ dbt.type_numeric() }}) as col_numeric_b,
     'c' as col_string_a,
     'abc' as col_string_b,
     null as col_null,
@@ -37,8 +37,8 @@ union all
 select
     4 as idx,
     '2020-10-23' as date_col,
-    0.5 as col_numeric_a,
-    0.5 as col_numeric_b,
+    cast(0.5 as {{ dbt.type_numeric() }}) as col_numeric_a,
+    cast(0.5 as {{ dbt.type_numeric() }}) as col_numeric_b,
     'c' as col_string_a,
     'abcd' as col_string_b,
     null as col_null,

--- a/integration_tests/models/schema_tests/data_test.sql
+++ b/integration_tests/models/schema_tests/data_test.sql
@@ -1,8 +1,8 @@
 select
     1 as idx,
     '2020-10-21' as date_col,
-    cast(0 as {{ dbt.type_float() }}) as col_numeric_a,
-    cast(1 as {{ dbt.type_float() }}) as col_numeric_b,
+    cast(0 as {{ dbt.type_numeric() }}) as col_numeric_a,
+    cast(1 as {{ dbt.type_numeric() }}) as col_numeric_b,
     'a' as col_string_a,
     'b' as col_string_b,
     cast(null as {{ dbt.type_string() }}) as col_null,

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -505,12 +505,12 @@ models:
               value_set: [0.5]
               top_n: 1
               quote_values: false
-              # Expect success if all most common values are in set 
+              # Expect success if all most common values at all n levels are in set 
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: [0.5, 0, 1]
               top_n: 2
               quote_values: false
-              # Expect failure if not all most common values are in set 
+              # Expect failure if not all most common values at all n levels are in set 
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: [0.5, 0]
               top_n: 2
@@ -518,7 +518,7 @@ models:
               config:
                 error_if: "=0"
                 warn_if: "<>1"
-              # Expect success if some of the most common values are in set and ties_okay is true
+              # Expect success if some of the most common values at all n levels are in set and ties_okay is true
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: [0.5, 0]
               top_n: 2
@@ -527,6 +527,12 @@ models:
               # Expect success if any of the top 2 most common levels value are in set and ties_okay is true
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: [0]
+              top_n: 2
+              ties_okay: true
+              quote_values: false
+              # Expect success if any of the top most common level value is in set and ties_okay is true
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: [0.5]
               top_n: 2
               ties_okay: true
               quote_values: false

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -505,6 +505,23 @@ models:
               value_set: [0.5]
               top_n: 1
               quote_values: false
+            # expect error if value is column but not most common
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: [1]
+              top_n: 1
+              quote_values: false
+              config:
+                error_if: "=0"
+                warn_if: "<>1"
+            # expect error if value is column but not most common and ties_okay is true
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: [1]
+              top_n: 1
+              ties_okay: true
+              quote_values: false
+              config:
+                error_if: "=0"
+                warn_if: "<>1"
           - dbt_expectations.expect_column_values_to_be_increasing:
               sort_column: col_numeric_a
               strictly: false
@@ -538,6 +555,55 @@ models:
           - dbt_expectations.expect_column_values_to_not_be_in_set:
               value_set: ['a','c']
               quote_values: true
+            # Expect error if not all most common values are in the set
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['b']
+              top_n: 1
+              config:
+                error_if: "=0"
+                warn_if: "<3"
+            # Expect success if not all most common values are in the set but ties_okay is set
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['b']
+              top_n: 1
+              ties_okay: true
+            # Expect error if none of the most common values are in the set and ties_okay is set
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['invalid_value']
+              top_n: 1
+              ties_okay: true
+              config:
+                error_if: "=0"
+                warn_if: "<4"
+            # Expect success if not all most common values are in the set but ties_okay is set
+            # and the set contains extra values 
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['b', 'invalid_value']
+              top_n: 1
+              ties_okay: true
+            # Expect success if not all most common values are in the set but ties_okay is set
+            # and value is not first one of the column naturally ordered
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['ab']
+              top_n: 1
+              ties_okay: true
+            # Expect success if all most common values are in the set
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['b', 'ab', 'abc', 'abcd']
+              top_n: 1
+            # Expect success if all most common values are in the set 
+            # and the set contains extra values 
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['b', 'ab', 'abc', 'abcd', 'invalid_value']
+              top_n: 1
+            # Expect error if none of the most common values are in the set 
+            # and the set contains extra values 
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['invalid_value1', 'invalid_value2', 'invalid_value3', 'invalid_value4', 'invalid_value5']
+              top_n: 1
+              config:
+                error_if: "=0"
+                warn_if: "<4"
           - dbt_expectations.expect_column_value_lengths_to_be_between:
               min_value: 1
               max_value: 4

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -513,11 +513,11 @@ models:
               config:
                 error_if: "=0"
                 warn_if: "<>1"
-            # expect error if value is column but not most common and ties_okay is true
+            # expect error if value is column but not most common and allow_ties is true
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: [1]
               top_n: 1
-              ties_okay: true
+              allow_ties: true
               quote_values: false
               config:
                 error_if: "=0"
@@ -562,31 +562,31 @@ models:
               config:
                 error_if: "=0"
                 warn_if: "<3"
-            # Expect success if not all most common values are in the set but ties_okay is set
+            # Expect success if not all most common values are in the set but allow_ties is set
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['b']
               top_n: 1
-              ties_okay: true
-            # Expect error if none of the most common values are in the set and ties_okay is set
+              allow_ties: true
+            # Expect error if none of the most common values are in the set and allow_ties is set
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['invalid_value']
               top_n: 1
-              ties_okay: true
+              allow_ties: true
               config:
                 error_if: "=0"
                 warn_if: "<4"
-            # Expect success if not all most common values are in the set but ties_okay is set
+            # Expect success if not all most common values are in the set but allow_ties is set
             # and the set contains extra values 
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['b', 'invalid_value']
               top_n: 1
-              ties_okay: true
-            # Expect success if not all most common values are in the set but ties_okay is set
+              allow_ties: true
+            # Expect success if not all most common values are in the set but allow_ties is set
             # and value is not first one of the column naturally ordered
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['ab']
               top_n: 1
-              ties_okay: true
+              allow_ties: true
             # Expect success if all most common values are in the set
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['b', 'ab', 'abc', 'abcd']

--- a/integration_tests/models/schema_tests/schema.yml
+++ b/integration_tests/models/schema_tests/schema.yml
@@ -505,7 +505,32 @@ models:
               value_set: [0.5]
               top_n: 1
               quote_values: false
-            # expect error if value is column but not most common
+              # Expect success if all most common values are in set 
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: [0.5, 0, 1]
+              top_n: 2
+              quote_values: false
+              # Expect failure if not all most common values are in set 
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: [0.5, 0]
+              top_n: 2
+              quote_values: false
+              config:
+                error_if: "=0"
+                warn_if: "<>1"
+              # Expect success if some of the most common values are in set and ties_okay is true
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: [0.5, 0]
+              top_n: 2
+              ties_okay: true
+              quote_values: false
+              # Expect success if any of the top 2 most common levels value are in set and ties_okay is true
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: [0]
+              top_n: 2
+              ties_okay: true
+              quote_values: false
+            # Expect error if value is in column but not most common
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: [1]
               top_n: 1
@@ -513,15 +538,24 @@ models:
               config:
                 error_if: "=0"
                 warn_if: "<>1"
-            # expect error if value is column but not most common and allow_ties is true
+            # Expect error if value is in column but not most common and ties_okay is true
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: [1]
               top_n: 1
-              allow_ties: true
+              ties_okay: true
               quote_values: false
               config:
                 error_if: "=0"
                 warn_if: "<>1"
+             # Expect error if value not in column at any level
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: [123456789]
+              top_n: >
+                (select count(*) from {{ref('data_test')}})
+              quote_values: false
+              config:
+                error_if: "=0"
+                warn_if: "<>3"
           - dbt_expectations.expect_column_values_to_be_increasing:
               sort_column: col_numeric_a
               strictly: false
@@ -562,31 +596,31 @@ models:
               config:
                 error_if: "=0"
                 warn_if: "<3"
-            # Expect success if not all most common values are in the set but allow_ties is set
+            # Expect success if not all most common values are in the set but ties_okay is set
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['b']
               top_n: 1
-              allow_ties: true
-            # Expect error if none of the most common values are in the set and allow_ties is set
+              ties_okay: true
+            # Expect error if none of the most common values are in the set and ties_okay is set
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['invalid_value']
               top_n: 1
-              allow_ties: true
+              ties_okay: true
               config:
                 error_if: "=0"
                 warn_if: "<4"
-            # Expect success if not all most common values are in the set but allow_ties is set
+            # Expect success if not all most common values are in the set but ties_okay is set
             # and the set contains extra values 
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['b', 'invalid_value']
               top_n: 1
-              allow_ties: true
-            # Expect success if not all most common values are in the set but allow_ties is set
+              ties_okay: true
+            # Expect success if not all most common values are in the set but ties_okay is set
             # and value is not first one of the column naturally ordered
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['ab']
               top_n: 1
-              allow_ties: true
+              ties_okay: true
             # Expect success if all most common values are in the set
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['b', 'ab', 'abc', 'abcd']
@@ -601,6 +635,16 @@ models:
           - dbt_expectations.expect_column_most_common_value_to_be_in_set:
               value_set: ['invalid_value1', 'invalid_value2', 'invalid_value3', 'invalid_value4', 'invalid_value5']
               top_n: 1
+              config:
+                error_if: "=0"
+                warn_if: "<4"
+            # Expect error if none of the most common values are in the set 
+            # and the set contains extra values 
+          - dbt_expectations.expect_column_most_common_value_to_be_in_set:
+              value_set: ['invalid_value1', 'invalid_value2', 'invalid_value3', 'invalid_value4', 'invalid_value5']
+              top_n: >
+                (select count(*) from {{ref('data_test')}})
+              ties_okay: true
               config:
                 error_if: "=0"
                 warn_if: "<4"

--- a/macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
@@ -5,13 +5,13 @@
                                                        quote_values=True,
                                                        data_type=None,
                                                        row_condition=None,
-                                                       allow_ties=False
+                                                       ties_okay=False
                                                        ) -%}
     {# For Snowflake, using a default 'decimal' instead of dbt.type_numeric() 
         rounds up the value when casting #}
     {% set data_type = dbt.type_numeric() if not data_type else data_type %}
     {{ adapter.dispatch('test_expect_column_most_common_value_to_be_in_set', 'dbt_expectations') (
-            model, column_name, value_set, top_n, quote_values, data_type, row_condition, allow_ties
+            model, column_name, value_set, top_n, quote_values, data_type, row_condition, ties_okay
         ) }}
 
 {%- endtest %}
@@ -23,7 +23,7 @@
                                                                       quote_values,
                                                                       data_type,
                                                                       row_condition,
-                                                                      allow_ties
+                                                                      ties_okay
                                                                       ) %}
 {% set data_type = data_type %}
 with value_counts as (
@@ -64,7 +64,7 @@ value_count_top_n as (
     from
         value_counts_ranked
     where
-        value_count_rank = {{ top_n }}
+        value_count_rank <= {{ top_n }}
 
 ),
 set_values as (
@@ -107,7 +107,7 @@ most_common_values_in_set as (
         most_common_values_not_in_set
 ),
 validation_errors as (
-    {% if allow_ties -%}
+    {% if ties_okay -%}
     select 
         * 
     from 

--- a/macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
+++ b/macros/schema_tests/aggregate_functions/expect_column_most_common_value_to_be_in_set.sql
@@ -4,11 +4,12 @@
                                                        top_n,
                                                        quote_values=True,
                                                        data_type="decimal",
-                                                       row_condition=None
+                                                       row_condition=None,
+                                                       ties_okay=False
                                                        ) -%}
 
     {{ adapter.dispatch('test_expect_column_most_common_value_to_be_in_set', 'dbt_expectations') (
-            model, column_name, value_set, top_n, quote_values, data_type, row_condition
+            model, column_name, value_set, top_n, quote_values, data_type, row_condition, ties_okay
         ) }}
 
 {%- endtest %}
@@ -19,7 +20,8 @@
                                                                       top_n,
                                                                       quote_values,
                                                                       data_type,
-                                                                      row_condition
+                                                                      row_condition,
+                                                                      ties_okay
                                                                       ) %}
 
 with value_counts as (
@@ -48,7 +50,7 @@ value_counts_ranked as (
 
     select
         *,
-        row_number() over(order by value_count desc) as value_count_rank
+        rank() over(order by value_count desc) as value_count_rank
     from
         value_counts
 
@@ -83,15 +85,23 @@ unique_set_values as (
         set_values
 
 ),
-validation_errors as (
-    -- values from the model that are not in the set
+most_common_values_not_in_set as (
     select
         value_field
     from
         value_count_top_n
     where
         value_field not in (select value_field from unique_set_values)
-
+),
+validation_errors as (
+    {% if ties_okay -%}
+    select mcvnis.* from most_common_values_not_in_set mcvnis
+    , (select count(*) as cnt from most_common_values_not_in_set) as most_common_values_not_in_set_cnt
+    , (select count(*) as cnt from value_count_top_n) as most_common_values_cnt
+    where most_common_values_not_in_set_cnt.cnt >= most_common_values_cnt.cnt
+    {%- else -%}
+    select * from most_common_values_not_in_set
+    {%- endif -%}
 )
 
 select *


### PR DESCRIPTION
## Issue this PR Addresses/Closes

Closes #258
Add expected-to-fail tests for expect_column_most_common_value_to_be_in_set (https://github.com/calogica/dbt-expectations/issues/207)
  
## Summary of Changes

Fixes tie handling of expect_column_most_common_value_to_be_in_set by rank()-ing the occurrences of column values instead of row_number()-ing them.
Adds a ties_okay to validate partial matches in case of ties.

## Why Do We Need These Changes
    
expect_column_most_common_value_to_be_in_set doesn't work reliably when multiple column values have the same occurrence. 

## Reviewers
@clausherther
