### PR TITLE
#257 Add count to expect_compound_columns_to_be_unique

### DIFF
--- a/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
+++ b/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
@@ -39,6 +39,7 @@ with validation_errors as (
         {% for column in columns -%}
         {{ column }}{% if not loop.last %},{% endif %}
         {%- endfor %}
+        ,count(*) as {{adapter.quote("n_records")}}
     from {{ model }}
     where
         1=1

--- a/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
+++ b/macros/schema_tests/multi-column/expect_compound_columns_to_be_unique.sql
@@ -37,9 +37,9 @@ with validation_errors as (
 
     select
         {% for column in columns -%}
-        {{ column }}{% if not loop.last %},{% endif %}
+        {{ column }},
         {%- endfor %}
-        ,count(*) as {{adapter.quote("n_records")}}
+        count(*) as {{adapter.quote("n_records")}}
     from {{ model }}
     where
         1=1


### PR DESCRIPTION
## Issue this PR Addresses/Closes

Closes #257 
  
## Summary of Changes

Just adds a `count(*) as n_records` to expect_compound_columns_to_be_unique

## Why Do We Need These Changes
    
Consistency between dbt-expectations and dbt-core uniqueness tests.  

  
## Reviewers
@clausherther
