### PR TITLE
Add duckdb support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -U pip setuptools wheel
-            pip install dbt-core==$DBT_VERSION dbt-postgres==$DBT_VERSION dbt-bigquery==$DBT_VERSION dbt-snowflake==$DBT_VERSION
+            pip install dbt-core==$DBT_VERSION dbt-postgres==$DBT_VERSION dbt-bigquery==$DBT_VERSION dbt-snowflake==$DBT_VERSION dbt-duckdb==$DBT_VERSION
 
       - run:
           name: Install dbt dependencies
@@ -75,6 +75,12 @@ jobs:
           command: |
             . venv/bin/activate
             dbt build -t snowflake --project-dir $DBT_PROJECT_DIR
+
+      - run:
+          name: "Run Tests - DuckDB"
+          command: |
+            . venv/bin/activate
+            dbt build -t duckdb --project-dir $DBT_PROJECT_DIR
 
       - store_artifacts:
           path: ./logs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       DBT_PROFILES_DIR: ./integration_tests/ci
       DBT_PROJECT_DIR: ./integration_tests
       BIGQUERY_SERVICE_KEY_PATH: "/home/circleci/bigquery-service-key.json"
-      DBT_VERSION: 1.4.1
+      DBT_VERSION: 1.6.0
 
     steps:
       - checkout

--- a/integration_tests/ci/profiles.yml
+++ b/integration_tests/ci/profiles.yml
@@ -33,4 +33,8 @@ integration_tests:
       schema: "{{ env_var('SNOWFLAKE_TEST_SCHEMA') }}"
       threads: 10
 
+    duckdb:
+      type: duckdb
+      path: ":memory:"
+
   target: postgres

--- a/integration_tests/models/schema_tests/timeseries_hourly.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly.sql
@@ -1,5 +1,9 @@
-{{ dbt_date.date_spine('hour',
-        start_date=dbt_date.n_days_ago(10),
-        end_date=dbt_date.tomorrow()
+{% set now = modules.datetime.datetime.now().replace(minute=0, hour=0, second=0, microsecond=0) %}
+{% set start_date = (now - modules.datetime.timedelta(10)).isoformat() %}
+
+{{ dbt_date.get_base_dates(
+        start_date=start_date,
+        end_date=now.isoformat(),
+        datepart="hour"
     )
 }}

--- a/integration_tests/models/schema_tests/timeseries_hourly.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly.sql
@@ -1,9 +1,9 @@
-{% set now = modules.datetime.datetime.now().replace(minute=0, hour=0, second=0, microsecond=0) %}
-{% set start_date = (now - modules.datetime.timedelta(10)) %}
+{% set end_date = modules.datetime.datetime.today().replace(hour=0, minute=0, second=0, microsecond=0) %}
+{% set start_date = (end_date - modules.datetime.timedelta(days=10)) %}
 
 {{ dbt_date.get_base_dates(
         start_date=start_date,
-        end_date=now,
+        end_date=end_date,
         datepart="hour"
     )
 }}

--- a/integration_tests/models/schema_tests/timeseries_hourly.sql
+++ b/integration_tests/models/schema_tests/timeseries_hourly.sql
@@ -1,9 +1,9 @@
 {% set now = modules.datetime.datetime.now().replace(minute=0, hour=0, second=0, microsecond=0) %}
-{% set start_date = (now - modules.datetime.timedelta(10)).isoformat() %}
+{% set start_date = (now - modules.datetime.timedelta(10)) %}
 
 {{ dbt_date.get_base_dates(
         start_date=start_date,
-        end_date=now.isoformat(),
+        end_date=now,
         datepart="hour"
     )
 }}

--- a/macros/math/rand.sql
+++ b/macros/math/rand.sql
@@ -31,3 +31,9 @@
     random()
 
 {%- endmacro -%}
+
+{% macro duckdb__rand() -%}
+
+    random()
+
+{%- endmacro -%}

--- a/macros/regex/regexp_instr.sql
+++ b/macros/regex/regexp_instr.sql
@@ -47,6 +47,12 @@ coalesce(array_length((select regexp_matches({{ source_value }}, '{{ regexp }}',
 regexp_instr({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }}, 0, '{{ flags }}')
 {% endmacro %}
 
+{% macro duckdb__regexp_instr(source_value, regexp, position, occurrence, is_raw, flags) %}
+{% if flags %}{{ dbt_expectations._validate_flags(flags, 'ciep') }}{% endif %}
+regexp_matches({{ source_value }}, '{{ regexp }}', '{{ flags }}')
+{% endmacro %}
+
+
 {% macro _validate_flags(flags, alphabet) %}
 {% for flag in flags %}
     {% if flag not in alphabet %}
@@ -74,7 +80,7 @@ regexp_instr({{ source_value }}, '{{ regexp }}', {{ position }}, {{ occurrence }
 {% if not is_match %}
     {# Using raise_compiler_error causes disabled tests with invalid flags to fail compilation #}
     {{ exceptions.warn(
-        "flags " ~ flags ~ " isn't a valid re2 flag pattern" 
+        "flags " ~ flags ~ " isn't a valid re2 flag pattern"
     ) }}
 {% endif %}
 {% endmacro %}

--- a/macros/utils/datatypes.sql
+++ b/macros/utils/datatypes.sql
@@ -33,3 +33,7 @@
 {% macro postgres__type_datetime() -%}
     timestamp without time zone
 {%- endmacro %}
+
+{% macro duckdb__type_datetime() -%}
+    timestamp
+{%- endmacro %}

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: calogica/dbt_date
-    version: [">=0.7.0", "<0.8.0"]
+    version: [">=0.8.0", "<0.9.0"]


### PR DESCRIPTION
## Summary of Changes

This PR adds support for duckdb, including updates to integration tests and CI.

## Why Do We Need These Changes
dbt-date recently added support for duckdb in conjunction with dbt metrics layer testing.  

## Reviewers
@jwills