### PR TITLE
add basic column tests for arrays and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ For example, use `America/New_York` for East Coast Time.
 - [expect_column_values_to_be_of_type](#expect_column_values_to_be_of_type)
 - [expect_column_values_to_be_in_type_list](#expect_column_values_to_be_in_type_list)
 - [expect_column_values_to_have_consistent_casing](#expect_column_values_to_have_consistent_casing)
+- [expect_array_column_to_not_be_empty](#expect_array_column_to_not_be_empty)
+- [expect_struct_column_to_not_be_empty](#expect_struct_column_to_not_be_empty)
 
 ### Sets and ranges
 
@@ -504,6 +506,31 @@ Expect a column to have consistent casing. By setting `display_inconsistent_colu
 tests:
   - dbt_expectations.expect_column_values_to_have_consistent_casing:
       display_inconsistent_columns: false # (Optional)
+```
+
+### [expect_array_column_to_not_be_empty](macros/schema_tests/column_values_basic/expect_array_column_to_not_be_empty.sql)
+
+Expect a column of type `array` to be filled with values. In Hive, this would mean to not have
+any value that looks like this '[]' or sometimes like this '[""]'
+
+*Applies to:* Column
+
+```yaml
+tests:
+  - dbt_expectations.expect_array_column_to_not_be_empty:
+      row_condition: "id is not null" # (Optional)
+```
+
+### [expect_struct_column_to_not_be_empty](macros/schema_tests/column_values_basic/expect_struct_column_to_not_be_empty.sql)
+
+Expect a column of type `struct(array)` to be filled with values. In Hive, this would mean to not have any value that has a size of zero.
+
+*Applies to:* Column
+
+```yaml
+tests:
+  - dbt_expectations.expect_struct_column_to_not_be_empty:
+      row_condition: "id is not null" # (Optional)
 ```
 
 ### [expect_column_values_to_be_in_set](macros/schema_tests/column_values_basic/expect_column_values_to_be_in_set.sql)

--- a/macros/schema_tests/column_values_basic/expect_array_column_to_not_be_empty.sql
+++ b/macros/schema_tests/column_values_basic/expect_array_column_to_not_be_empty.sql
@@ -1,0 +1,27 @@
+{% test expect_array_column_to_not_be_empty(model, column_name, row_condition = None) %}
+
+with validation as (
+
+    select {{ column_name }} as array_column
+    from {{ model }}
+    {%- if row_condition %}
+    where
+        {{ row_condition }}
+    {% endif %}
+
+),
+
+validation_errors as (
+
+    select array_contains(array_column, '') as metric_1,
+           size(array_column) as metric_2
+    from validation
+
+)
+select *
+from validation_errors
+where
+    metric_1 = True
+    or metric_2 = 0
+
+{% endtest %}

--- a/macros/schema_tests/column_values_basic/expect_struct_column_to_not_be_empty.sql
+++ b/macros/schema_tests/column_values_basic/expect_struct_column_to_not_be_empty.sql
@@ -1,0 +1,25 @@
+{% test expect_struct_column_to_not_be_empty(model, column_name, row_condition = None) %}
+
+with validation as (
+
+    select {{ column_name }} as array_column
+    from {{ model }}
+    {%- if row_condition %}
+    where
+        {{ row_condition }}
+    {% endif %}
+
+),
+
+validation_errors as (
+
+    select size(array_column) as metric
+    from validation
+
+)
+select *
+from validation_errors
+where
+    metric = 0
+
+{% endtest %}


### PR DESCRIPTION
## Issue this PR Addresses/Closes

#272

  
## Summary of Changes

Added two new tests to the "column_values_basic" directory and updated the readme-file:
- expect_array_column_to_not_be_empty
- expect_struct_column_to_not_be_empty

## Why Do We Need These Changes
    
For tables that contain columns of type `array` or `array(struct)`, the values can be sometimes empty without being NULL (e.g. `[ ]`, or `[" "]`. In this case, the test to **expect_column_values_to_not_be_null.sql** could be misleading and mask the issue of having empty values. So we would need to make use of Hive functions to assert the array is indeed empty.

  
## Reviewers
@clausherther
