### PR TITLE
Update dbt-date dependency

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: calogica/dbt_date
-    version: [">=0.8.0", "<0.9.0"]
+    version: [">=0.9.0", "<0.10.0"]


### PR DESCRIPTION
## Issue this PR Addresses/Closes

Closes #277 

 
## Summary of Changes

Update the dependency that dbt-expectations has with dbt-date

## Why Do We Need These Changes

When running `dbt deps` it notifies me that there is a new update available. 
![image](https://github.com/calogica/dbt-expectations/assets/132364/3b9648b1-2830-4456-a939-6cbe9e783e68)

This update will not be installed due to the less then rule in the `packages.yml` file.

  
## Reviewers
@clausherther
