### PR TITLE
Change dbt-date version dependency upper range

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: calogica/dbt_date
-    version: [">=0.9.0", "<0.10.0"]
+    version: [">=0.9.0", "<1.0.0"]


### PR DESCRIPTION
This increases the version dependency upper range for dbt-date so that new minor releases are included automatically, making dependency management easier down the road.
  
## Reviewers
@clausherther
