### PR TITLE
Add Trino md5 macro

### DIFF
--- a/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
+++ b/macros/schema_tests/multi-column/expect_select_column_values_to_be_unique_within_record.sql
@@ -55,7 +55,7 @@ with column_values as (
 unpivot_columns as (
 
     {% for column in columns %}
-    select row_index, '{{ column }}' as column_name, md5({{ column }}) as column_value from column_values
+    select row_index, '{{ column }}' as column_name, {{ dbt_expectations.md5(column) }} as column_value from column_values
     {% if not loop.last %}union all{% endif %}
     {% endfor %}
 ),

--- a/macros/utils/md5.sql
+++ b/macros/utils/md5.sql
@@ -1,0 +1,16 @@
+{%- macro md5(string_value) -%}
+    {{ return(adapter.dispatch('md5', 'dbt_expectations')(string_value)) }}
+{% endmacro %}
+
+{%- macro default__md5(string_value) -%}
+
+  {{ dbt.hash(string_value) }}
+
+{%- endmacro -%}
+
+
+{%- macro trino__md5(string_value) -%}
+
+  md5(cast({{ string_value }} as varbinary))
+
+{%- endmacro -%}


### PR DESCRIPTION
Adds support for `md5` on Trino which doesn't support varchars for md5.