### PR TITLE
Add tox + GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+# **what?**
+# Run tests for dbt-codegen against supported adapters
+
+# **why?**
+# To ensure that dbt-codegen works as expected with all supported adapters
+
+# **when?**
+# On every PR, and every push to main and when manually triggered
+
+name: Package Integration Tests
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+    workflow_dispatch:
+
+jobs:
+  run-tests:
+      uses: dbt-labs/dbt-package-testing/.github/workflows/run_tox.yml@main
+      # this just tests with postgres so no variables need to be passed through.
+      # When it's time to add more adapters you will need to pass through inputs for
+      # the other adapters as shown in the below example for redshift
+    #   with:
+    #     # redshift
+    #     REDSHIFT_HOST: ${{ vars.REDSHIFT_HOST }}
+    #     REDSHIFT_USER: ${{ vars.REDSHIFT_USER }}
+    #     REDSHIFT_DATABASE: ${{ vars.REDSHIFT_DATABASE }}
+    #     REDSHIFT_SCHEMA: "integration_tests_redshift_${{ github.run_number }}"
+    #     REDSHIFT_PORT: ${{ vars.REDSHIFT_PORT }}
+    #   secrets:
+    #     DBT_ENV_SECRET_REDSHIFT_PASS: ${{ secrets.DBT_ENV_SECRET_REDSHIFT_PASS }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target/
 dbt_packages/
 logs/
+env/
 .python-version
 integration_tests/.spark-warehouse
 integration_tests/.hive-metastore

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+# for convenience - test locally against latest changes in dbt-core + adapters
+dbt-core@git+https://github.com/dbt-labs/dbt-core.git#subdirectory=core
+dbt-postgres@git+https://github.com/dbt-labs/dbt-postgres.git
+tox>=3.13

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -22,6 +22,7 @@ dispatch:
 flags:
   partial_parse: True
   send_anonymous_usage_stats: False
+  use_colors: True
   warn_error_options:
     silence: # To silence or ignore dbt 1.8.x upgrade warnings
       - TestsConfigDeprecation

--- a/integration_tests/package-lock.yml
+++ b/integration_tests/package-lock.yml
@@ -1,0 +1,5 @@
+packages:
+  - local: ../
+  - package: calogica/dbt_date
+    version: 0.10.1
+sha1_hash: de2deba3d66ce03d8c02949013650cc9b94f6030

--- a/integration_tests/profiles.yml
+++ b/integration_tests/profiles.yml
@@ -1,0 +1,12 @@
+integration_tests:
+  outputs:
+    postgres:
+      type: "postgres"
+      host: "{{ env_var('POSTGRES_HOST') }}"
+      user: "{{ env_var('POSTGRES_USER') }}"
+      pass: "{{ env_var('DBT_ENV_SECRET_POSTGRES_PASS') }}"
+      port: "{{ env_var('POSTGRES_PORT') | as_number }}"
+      dbname: "{{ env_var('POSTGRES_DATABASE') }}"
+      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
+      threads: 5
+  target: postgres

--- a/supported_adapters.env
+++ b/supported_adapters.env
@@ -1,0 +1,1 @@
+SUPPORTED_ADAPTERS=postgres

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+skipsdist = True
+envlist = lint_all, testenv
+
+[testenv]
+passenv =
+    # postgres env vars
+    POSTGRES_HOST
+    POSTGRES_USER
+    DBT_ENV_SECRET_POSTGRES_PASS
+    POSTGRES_PORT
+    POSTGRES_DATABASE
+    POSTGRES_SCHEMA
+
+# Postgres integration tests for centralized dbt testing
+# run dbt commands directly, assumes dbt is already installed in environment
+[testenv:dbt_integration_postgres]
+changedir = integration_tests
+allowlist_externals = 
+    dbt
+skip_install = true
+commands =
+    dbt deps --target postgres
+    dbt build --target postgres


### PR DESCRIPTION
## Issue this PR Addresses/Closes

Closes #318
  
## Summary of Changes

- Add `tox` with Postgres as target (`dbt_integration_postgres`)
- Add GitHub Action for running integration tests against Postgres via `tox`
- [Nice to have] Add `dev-requirements.txt` to install `tox` and latest `dbt-core` + `dbt-postgres` for local development/testing
- TODO: Set up integration tests for other adapters by adding to `tox.ini` + `supported_adapters.env` + GH workflow.
    - To be compatible with dbt Labs' continuous  env vars need to match the naming convention described in https://github.com/dbt-labs/dbt-core/discussions/10668.
    - This should enable you to fully remove integration tests running on CircleCI. (I have left `integration_tests/ci/profiles.yml` in place so that CircleCI can continue running unchanged in the meantime.)

```
dbt_integration_postgres: commands[0] /Users/jerco/dev/product/packages/dbt-expectations/integration_tests> dbt deps --target postgres
15:00:17  Running with dbt=1.9.0-a1
15:00:17  Installing ../
15:00:17  Installed from <local @ ../>
15:00:17  Installing calogica/dbt_date
15:00:18  Installed from version 0.10.1
15:00:18  Up to date!
dbt_integration_postgres: commands[1] /Users/jerco/dev/product/packages/dbt-expectations/integration_tests> dbt build --target postgres
15:00:18  Running with dbt=1.9.0-a1
15:00:19  Registered adapter: postgres=1.9.0-a1
15:00:19  Unable to do partial parsing because saved manifest not found. Starting full parse.
15:00:20  Found 12 models, 157 data tests, 685 macros
15:00:20  
15:00:20  Concurrency: 5 threads (target='postgres')
...
15:00:22  Done. PASS=169 WARN=0 ERROR=0 SKIP=0 TOTAL=169
  dbt_integration_postgres: OK (5.22=setup[0.03]+cmd[1.43,3.76] seconds)
  congratulations :) (5.28 seconds)
```

## Why Do We Need These Changes
    
As explained in #318, by setting up `tox` as a standard entry-point, the Core development team at dbt Labs can include `dbt-expectations` integration tests (along with other popular dbt packages) as part of our continuous development & delivery of dbt.

## Reviewers
@clausherther
