### PR TITLE
Adding support for ClickHouse specific lagInFrame function in tests

### DIFF
--- a/macros/utils/lag.sql
+++ b/macros/utils/lag.sql
@@ -1,0 +1,26 @@
+{%- macro lag(value_field, offset=None, default_value=None, partition_by=None, order_by=None, window_definition=None) -%}
+    {{ return(adapter.dispatch('lag', 'dbt_expectations')(value_field, offset, default_value, partition_by, order_by, window_definition)) }}
+{% endmacro %}
+
+{%- macro default__lag(value_field, offset, default_value, partition_by, order_by, window_definition) -%}
+{%- set partition_by_clause = "partition by " ~ partition_by if partition_by else "" -%}
+{%- set order_by_clause = "order by " ~ order_by if order_by else "" -%}
+{%- set window_definition_clause = window_definition if window_definition else "" -%}
+{%- set offset_clause = ", " ~ offset if offset else "" -%}
+{%- set default_value_clause = ", " ~ default_value if default_value else "" -%}
+
+  lag({{ value_field }} {{ offset_clause }} {{ default_value_clause }}) over({{ partition_by_clause }} {{ order_by_clause }} {{ window_definition_clause }})
+
+{%- endmacro -%}
+
+
+{%- macro clickhouse__lag(value_field, offset, default_value, partition_by, order_by, window_definition) -%}
+{%- set partition_by_clause = "partition by " ~ partition_by if partition_by else "" -%}
+{%- set order_by_clause = "order by " ~ order_by if order_by else "" -%}
+{%- set window_definition_clause = window_definition if window_definition else "rows between unbounded preceding and unbounded following" -%}
+{%- set offset_clause = ", " ~ offset if offset else "" -%}
+{%- set default_value_clause = ", " ~ default_value if default_value else "" -%}
+
+  lagInFrame({{ value_field }} {{ offset_clause }} {{ default_value_clause }}) over({{ partition_by_clause }} {{ order_by_clause }} {{ window_definition_clause }})
+
+{%- endmacro -%}


### PR DESCRIPTION
## Issue this PR Addresses/Closes

Closes #324 
  
## Summary of Changes

New utility macro _lag_ was added to support ClickHouse specific _lagInFrame_ function and to ensure support for all other sql dialects while keeping the test code clean and readable. This macro is used in the 3 tests which use _lag_ function to ensure ClickHouse compatibility

## Why Do We Need These Changes
    
It's needed to add support for ClickHouse in the current 3 tests which use the _lag_ function and any future tests which will use _lag_ function.

  
## Reviewers
@clausherther
